### PR TITLE
add polling, debug mode, live reload modes, fix theme sse connection culling issue caused hangs

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ go install github.com/sphireinc/foundry/cmd/foundry@latest
 foundry version
 foundry build
 foundry serve
+foundry serve --debug
 foundry serve-preview
 foundry plugin list --enabled
 foundry theme list
@@ -97,6 +98,17 @@ foundry routes check
 2. Add pages and posts under `content/pages` and `content/posts`.
 3. Run `foundry serve` during development.
 4. Run `foundry build` to generate static output in `public/`.
+
+If a page appears to hang during local preview, run `foundry serve --debug` to emit per-request timing plus runtime snapshots, including:
+
+- heap allocation and in-use heap
+- stack and total runtime memory
+- goroutine count
+- active request count
+- GC count
+- process user/system CPU time and request CPU percentage estimates
+
+If live reload causes browser connection stalls in development, switch `server.live_reload_mode` from `stream` to `poll`. `stream` uses Server-Sent Events and refreshes immediately. `poll` trades a small delay for simpler connection behavior.
 
 ## Content model
 
@@ -168,6 +180,15 @@ Accepted request auth headers:
 `security.allow_unsafe_html` controls whether raw HTML in Markdown is preserved in rendered output.
 
 ### Server
+
+`server.live_reload` turns live reload on during local preview.
+
+`server.live_reload_mode` controls the transport:
+
+- `stream`: uses a long-lived SSE connection to `/__reload`
+- `poll`: polls `/__reload/poll` every 1.5 seconds and reloads when the rebuild version changes
+
+Use `poll` if your browser or proxy environment is sensitive to long-lived local connections.
 
 The preview/admin server uses explicit read, write, and idle timeouts by default.
 

--- a/cmd/foundry/main.go
+++ b/cmd/foundry/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 
 	_ "github.com/sphireinc/foundry/internal/commands/imports"
 	"github.com/sphireinc/foundry/internal/commands/registry"
@@ -78,17 +79,27 @@ func main() {
 		_, _ = fmt.Println("build complete")
 
 	case "serve":
+		serveDebug, err := parseServeDebugFlag(os.Args[2:])
+		if err != nil {
+			exitWithError(diag.Wrap(diag.KindUsage, "parse serve flags", err))
+		}
+
 		loader := content.NewLoader(cfg, pluginManager, false)
 		hooks := adminhttp.NewHooks(cfg, pluginManager)
-		srv := server.New(cfg, loader, routeResolver, rendererEngine, hooks, false)
+		srv := server.New(cfg, loader, routeResolver, rendererEngine, hooks, false, server.WithDebugMode(serveDebug))
 		if err := srv.ListenAndServe(ctx); err != nil {
 			exitWithError(diag.Wrap(diag.KindServe, "serve site", err))
 		}
 
 	case "serve-preview":
+		serveDebug, err := parseServeDebugFlag(os.Args[2:])
+		if err != nil {
+			exitWithError(diag.Wrap(diag.KindUsage, "parse serve-preview flags", err))
+		}
+
 		loader := content.NewLoader(cfg, pluginManager, true)
 		hooks := adminhttp.NewHooks(cfg, pluginManager)
-		srv := server.New(cfg, loader, routeResolver, rendererEngine, hooks, true)
+		srv := server.New(cfg, loader, routeResolver, rendererEngine, hooks, true, server.WithDebugMode(serveDebug))
 		if err := srv.ListenAndServe(ctx); err != nil {
 			exitWithError(diag.Wrap(diag.KindServe, "serve preview site", err))
 		}
@@ -130,6 +141,23 @@ func handleConfigBoundCLI(cfg *config.Config, args []string) {
 
 func printUsage() {
 	fmt.Println(registry.Usage())
+}
+
+func parseServeDebugFlag(args []string) (bool, error) {
+	debug := false
+
+	for _, arg := range args {
+		switch strings.TrimSpace(arg) {
+		case "":
+			continue
+		case "--debug":
+			debug = true
+		default:
+			return false, fmt.Errorf("unknown serve flag: %s", arg)
+		}
+	}
+
+	return debug, nil
 }
 
 func exitWithError(err error) {

--- a/cmd/foundry/main_test.go
+++ b/cmd/foundry/main_test.go
@@ -22,3 +22,19 @@ func TestHandleConfigFreeCLI(t *testing.T) {
 func TestHandleConfigBoundCLINoCommand(t *testing.T) {
 	handleConfigBoundCLI(&config.Config{}, []string{"foundry", "unknown"})
 }
+
+func TestParseServeDebugFlag(t *testing.T) {
+	debug, err := parseServeDebugFlag([]string{"--debug"})
+	if err != nil || !debug {
+		t.Fatalf("expected serve debug flag to be parsed, got debug=%v err=%v", debug, err)
+	}
+
+	debug, err = parseServeDebugFlag(nil)
+	if err != nil || debug {
+		t.Fatalf("expected empty serve args to be accepted, got debug=%v err=%v", debug, err)
+	}
+
+	if _, err := parseServeDebugFlag([]string{"--nope"}); err == nil {
+		t.Fatal("expected unknown serve flag to fail")
+	}
+}

--- a/docs/getting-started/index.html
+++ b/docs/getting-started/index.html
@@ -58,16 +58,20 @@ docs/      GitHub Pages content and generated coverage output</code></pre>
         <pre><code>foundry version
 foundry build
 foundry serve
+foundry serve --debug
 foundry serve-preview
 foundry plugin list --enabled
 foundry theme list
 foundry routes check</code></pre>
 
+        <p>If a page appears to stall during local preview, run <code>foundry serve --debug</code> to log request timing, slow-render warnings, memory snapshots, goroutine counts, active request counts, and process CPU time deltas.</p>
+        <p>Live reload supports two transport modes. <code>stream</code> uses Server-Sent Events and is the default. <code>poll</code> checks a lightweight endpoint every 1.5 seconds and is the safer choice if your browser hits local connection limits while reloading.</p>
+
         <h2>Important config groups</h2>
         <ul>
           <li><strong>Admin:</strong> set <code>admin.access_token</code> whenever the admin surface is enabled.</li>
           <li><strong>Security:</strong> <code>security.allow_unsafe_html</code> controls whether raw HTML is preserved in Markdown output.</li>
-          <li><strong>Server:</strong> preview/admin serving uses read, write, and idle timeouts by default.</li>
+          <li><strong>Server:</strong> preview/admin serving uses read, write, and idle timeouts by default, and live reload can run in <code>stream</code> or <code>poll</code> mode.</li>
           <li><strong>Taxonomies:</strong> default and custom taxonomies participate in rendering and incremental rebuild planning.</li>
           <li><strong>Plugins:</strong> enabled plugins are validated and synced into generated registration code.</li>
           <li><strong>Themes:</strong> themes must satisfy the minimum slot contract validated by <code>foundry theme validate</code>.</li>

--- a/docs/index.html
+++ b/docs/index.html
@@ -136,7 +136,7 @@
           </article>
           <article class="feature">
             <h3>Admin and preview guardrails</h3>
-            <p>The admin surface requires <code>admin.access_token</code>, raw HTML handling is config-controlled, and the preview/admin server uses timeouts.</p>
+            <p>The admin surface requires <code>admin.access_token</code>, raw HTML handling is config-controlled, the preview/admin server uses timeouts, and live reload supports both SSE and polling modes.</p>
           </article>
         </div>
       </section>

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,5 +1,7 @@
 package config
 
+import "strings"
+
 type Config struct {
 	Name        string                `yaml:"name"`
 	Title       string                `yaml:"title"`
@@ -37,6 +39,7 @@ type AdminConfig struct {
 type ServerConfig struct {
 	Addr            string `yaml:"addr"`
 	LiveReload      bool   `yaml:"live_reload"`
+	LiveReloadMode  string `yaml:"live_reload_mode"`
 	AutoOpenBrowser bool   `yaml:"auto_open_browser"`
 	DebugRoutes     bool   `yaml:"debug_routes"`
 }
@@ -146,6 +149,11 @@ func (c *Config) ApplyDefaults() {
 	}
 	if c.Server.Addr == "" {
 		c.Server.Addr = ":8080"
+	}
+	if strings.TrimSpace(c.Server.LiveReloadMode) == "" {
+		c.Server.LiveReloadMode = "stream"
+	} else {
+		c.Server.LiveReloadMode = strings.ToLower(strings.TrimSpace(c.Server.LiveReloadMode))
 	}
 	if c.Content.PagesDir == "" {
 		c.Content.PagesDir = "pages"

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -13,6 +13,9 @@ func TestApplyDefaults(t *testing.T) {
 	if cfg.Name == "" || cfg.Theme == "" || cfg.Server.Addr == "" {
 		t.Fatalf("expected defaults to be applied: %#v", cfg)
 	}
+	if cfg.Server.LiveReloadMode != "stream" {
+		t.Fatalf("expected live reload mode default to be stream, got %q", cfg.Server.LiveReloadMode)
+	}
 	if cfg.Admin.LocalOnly != true {
 		t.Fatalf("expected admin local only default to be true")
 	}
@@ -24,7 +27,7 @@ func TestApplyDefaults(t *testing.T) {
 func TestLoadValidateAndEditYAML(t *testing.T) {
 	root := t.TempDir()
 	path := filepath.Join(root, "site.yaml")
-	body := []byte("theme: default\ndefault_lang: en\ncontent_dir: content\npublic_dir: public\nthemes_dir: themes\ndata_dir: data\nplugins_dir: plugins\nserver:\n  addr: :8080\nfeed:\n  rss_path: /rss.xml\n  sitemap_path: /sitemap.xml\nplugins:\n  enabled:\n    - toc\n")
+	body := []byte("theme: default\ndefault_lang: en\ncontent_dir: content\npublic_dir: public\nthemes_dir: themes\ndata_dir: data\nplugins_dir: plugins\nserver:\n  addr: :8080\n  live_reload_mode: poll\nfeed:\n  rss_path: /rss.xml\n  sitemap_path: /sitemap.xml\nplugins:\n  enabled:\n    - toc\n")
 	if err := os.WriteFile(path, body, 0o644); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
@@ -60,6 +63,7 @@ func TestValidateAndSequenceHelpersErrors(t *testing.T) {
 	cfg := &Config{
 		Theme:   "..",
 		Plugins: PluginConfig{Enabled: []string{"../escape"}},
+		Server:  ServerConfig{LiveReloadMode: "invalid"},
 		Admin:   AdminConfig{Enabled: true},
 		Feed: FeedConfig{
 			RSSPath:     "rss.xml",

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -39,6 +39,7 @@ func Validate(cfg *Config) []error {
 	require("server.addr", cfg.Server.Addr)
 	require("feed.rss_path", cfg.Feed.RSSPath)
 	require("feed.sitemap_path", cfg.Feed.SitemapPath)
+	require("server.live_reload_mode", cfg.Server.LiveReloadMode)
 
 	if cfg.Feed.RSSPath != "" && !strings.HasPrefix(cfg.Feed.RSSPath, "/") {
 		errs = append(errs, fmt.Errorf("feed.rss_path must start with '/'"))
@@ -48,6 +49,13 @@ func Validate(cfg *Config) []error {
 	}
 	if cfg.Feed.RSSPath != "" && cfg.Feed.RSSPath == cfg.Feed.SitemapPath {
 		errs = append(errs, fmt.Errorf("feed.rss_path and feed.sitemap_path must not be the same"))
+	}
+	if cfg.Server.LiveReloadMode != "" {
+		switch strings.ToLower(strings.TrimSpace(cfg.Server.LiveReloadMode)) {
+		case "stream", "poll":
+		default:
+			errs = append(errs, fmt.Errorf("server.live_reload_mode must be one of: stream, poll"))
+		}
 	}
 
 	if cfg.DefaultLang != "" && strings.Contains(cfg.DefaultLang, "/") {

--- a/internal/server/cputime_other.go
+++ b/internal/server/cputime_other.go
@@ -1,0 +1,9 @@
+//go:build !darwin && !linux
+
+package server
+
+import "time"
+
+func processCPUTime() (time.Duration, time.Duration) {
+	return 0, 0
+}

--- a/internal/server/cputime_unix.go
+++ b/internal/server/cputime_unix.go
@@ -1,0 +1,21 @@
+//go:build darwin || linux
+
+package server
+
+import (
+	"syscall"
+	"time"
+)
+
+func processCPUTime() (time.Duration, time.Duration) {
+	var usage syscall.Rusage
+	if err := syscall.Getrusage(syscall.RUSAGE_SELF, &usage); err != nil {
+		return 0, 0
+	}
+
+	return timevalToDuration(usage.Utime), timevalToDuration(usage.Stime)
+}
+
+func timevalToDuration(tv syscall.Timeval) time.Duration {
+	return time.Duration(tv.Sec)*time.Second + time.Duration(tv.Usec)*time.Microsecond
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,15 +1,20 @@
 package server
 
 import (
+	"bufio"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"os"
 	"path/filepath"
+	"runtime"
+	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/fsnotify/fsnotify"
@@ -49,10 +54,40 @@ type Server struct {
 	renderer     *renderer.Renderer
 	hooks        Hooks
 	preview      bool
+	debug        bool
+	activeReqs   atomic.Int64
+	connMu       sync.Mutex
+	connStates   map[net.Conn]http.ConnState
 	mu           sync.RWMutex
 	graph        *content.SiteGraph
 	depGraph     *deps.Graph
 	reloadSignal chan struct{}
+	reloadVer    atomic.Uint64
+}
+
+type Option func(*Server)
+
+var requestSequence atomic.Uint64
+
+const slowServeRequestInterval = 2 * time.Second
+const debugHeartbeatInterval = 2 * time.Second
+
+type runtimeSnapshot struct {
+	HeapAllocBytes   uint64
+	HeapInuseBytes   uint64
+	StackInuseBytes  uint64
+	SysBytes         uint64
+	NumGC            uint32
+	Goroutines       int
+	ActiveRequests   int64
+	ProcessUserCPU   time.Duration
+	ProcessSystemCPU time.Duration
+}
+
+func WithDebugMode(enabled bool) Option {
+	return func(s *Server) {
+		s.debug = enabled
+	}
 }
 
 func New(
@@ -62,20 +97,30 @@ func New(
 	renderer *renderer.Renderer,
 	hooks Hooks,
 	preview bool,
+	opts ...Option,
 ) *Server {
 	if hooks == nil {
 		hooks = noopHooks{}
 	}
 
-	return &Server{
+	s := &Server{
 		cfg:          cfg,
 		loader:       loader,
 		router:       router,
 		renderer:     renderer,
 		hooks:        hooks,
 		preview:      preview,
+		connStates:   make(map[net.Conn]http.ConnState),
 		reloadSignal: make(chan struct{}, 1),
 	}
+
+	for _, opt := range opts {
+		if opt != nil {
+			opt(s)
+		}
+	}
+
+	return s
 }
 
 func (s *Server) ListenAndServe(ctx context.Context) error {
@@ -101,6 +146,9 @@ func (s *Server) ListenAndServe(ctx context.Context) error {
 	if s.cfg.Server.AutoOpenBrowser {
 		go s.openBrowserAfterStartup(serverURL)
 	}
+	if s.debug {
+		go s.debugHeartbeat(ctx)
+	}
 
 	srv := s.newHTTPServer(s.newMux())
 	go s.shutdownOnContextDone(ctx, srv)
@@ -117,6 +165,7 @@ func (s *Server) newMux() *http.ServeMux {
 
 	if s.cfg.Server.LiveReload {
 		mux.HandleFunc("/__reload", s.handleReload)
+		mux.HandleFunc("/__reload/poll", s.handleReloadPoll)
 	}
 	if s.cfg.Server.DebugRoutes {
 		mux.HandleFunc("/__debug/deps", s.handleDepsDebug)
@@ -132,11 +181,15 @@ func (s *Server) newMux() *http.ServeMux {
 	s.hooks.RegisterRoutes(mux)
 	mux.HandleFunc("/", s.handlePage)
 
+	if s.debug {
+		return s.wrapDebugHTTP(mux)
+	}
+
 	return mux
 }
 
 func (s *Server) newHTTPServer(handler http.Handler) *http.Server {
-	return &http.Server{
+	srv := &http.Server{
 		Addr:              s.cfg.Server.Addr,
 		Handler:           handler,
 		ReadHeaderTimeout: 5 * time.Second,
@@ -144,6 +197,10 @@ func (s *Server) newHTTPServer(handler http.Handler) *http.Server {
 		WriteTimeout:      30 * time.Second,
 		IdleTimeout:       120 * time.Second,
 	}
+	if s.debug {
+		srv.ConnState = s.onConnState
+	}
+	return srv
 }
 
 func (s *Server) shutdownOnContextDone(ctx context.Context, srv *http.Server) {
@@ -175,6 +232,12 @@ func (s *Server) listenURL() string {
 }
 
 func (s *Server) rebuild(ctx context.Context) error {
+	start := time.Now()
+	before := s.captureRuntimeSnapshot()
+	if s.debug {
+		logx.Info("serve rebuild started", append([]any{"preview", s.preview}, before.logFields("runtime_")...)...)
+	}
+
 	graph, err := s.loadPreparedGraph(ctx)
 	if err != nil {
 		return err
@@ -185,11 +248,32 @@ func (s *Server) rebuild(ctx context.Context) error {
 
 	s.updateGraphState(graph)
 	logx.Info("site rebuilt", "documents", len(graph.Documents), "routes", len(graph.ByURL))
+	if s.debug {
+		after := s.captureRuntimeSnapshot()
+		args := []any{"elapsed", time.Since(start).String()}
+		args = append(args, after.logFields("runtime_")...)
+		args = append(args, after.deltaFields(before, time.Since(start), "delta_")...)
+		logx.Info("serve rebuild finished", args...)
+	}
 	s.signalReload()
 	return nil
 }
 
 func (s *Server) incrementalRebuild(ctx context.Context, changes deps.ChangeSet) error {
+	start := time.Now()
+	before := s.captureRuntimeSnapshot()
+	if s.debug {
+		args := []any{
+			"full", changes.Full,
+			"sources", len(changes.Sources),
+			"templates", len(changes.Templates),
+			"data_keys", len(changes.DataKeys),
+			"assets", len(changes.Assets),
+		}
+		args = append(args, before.logFields("runtime_")...)
+		logx.Info("serve incremental rebuild started", args...)
+	}
+
 	oldDepGraph := s.currentDepGraph()
 
 	if len(changes.Assets) > 0 {
@@ -227,6 +311,16 @@ func (s *Server) incrementalRebuild(ctx context.Context, changes deps.ChangeSet)
 
 	s.updateGraphState(graph)
 	logx.Debug("incremental rebuild complete", "output_count", len(plan.OutputURLs))
+	if s.debug {
+		after := s.captureRuntimeSnapshot()
+		args := []any{
+			"outputs", len(plan.OutputURLs),
+			"elapsed", time.Since(start).String(),
+		}
+		args = append(args, after.logFields("runtime_")...)
+		args = append(args, after.deltaFields(before, time.Since(start), "delta_")...)
+		logx.Info("serve incremental rebuild finished", args...)
+	}
 	s.signalReload()
 	return nil
 }
@@ -273,6 +367,7 @@ func hasRenderableChanges(changes deps.ChangeSet) bool {
 }
 
 func (s *Server) signalReload() {
+	s.reloadVer.Add(1)
 	select {
 	case s.reloadSignal <- struct{}{}:
 	default:
@@ -452,16 +547,62 @@ func (s *Server) handleReload(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("Connection", "keep-alive")
 
+	lastSeen := s.reloadVer.Load()
 	notify := r.Context().Done()
+	ticker := time.NewTicker(1 * time.Second)
+	defer ticker.Stop()
 	for {
 		select {
 		case <-notify:
 			return
 		case <-s.reloadSignal:
-			_, _ = fmt.Fprintf(w, "data: %s\n\n", `{"reload":true}`)
-			flusher.Flush()
+			if s.writeReloadEvent(w, flusher, &lastSeen) {
+				return
+			}
+		case <-ticker.C:
+			if s.writeReloadEvent(w, flusher, &lastSeen) {
+				return
+			}
 		}
 	}
+}
+
+func (s *Server) handleReloadPoll(w http.ResponseWriter, r *http.Request) {
+	current := s.reloadVer.Load()
+	since := parseReloadVersion(r.URL.Query().Get("since"))
+
+	payload := map[string]any{
+		"version": current,
+		"reload":  since > 0 && current > since,
+	}
+
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.Header().Set("Cache-Control", "no-cache")
+	_ = json.NewEncoder(w).Encode(payload)
+}
+
+func (s *Server) writeReloadEvent(w http.ResponseWriter, flusher http.Flusher, lastSeen *uint64) bool {
+	current := s.reloadVer.Load()
+	if current <= *lastSeen {
+		return false
+	}
+	*lastSeen = current
+	if _, err := fmt.Fprintf(w, "data: %s\n\n", `{"reload":true}`); err != nil {
+		return true
+	}
+	flusher.Flush()
+	return false
+}
+
+func parseReloadVersion(raw string) uint64 {
+	if strings.TrimSpace(raw) == "" {
+		return 0
+	}
+	value, err := strconv.ParseUint(strings.TrimSpace(raw), 10, 64)
+	if err != nil {
+		return 0
+	}
+	return value
 }
 
 func (s *Server) handlePage(w http.ResponseWriter, r *http.Request) {
@@ -474,7 +615,9 @@ func (s *Server) handlePage(w http.ResponseWriter, r *http.Request) {
 		path += "/"
 	}
 
+	_, finishDebug := s.beginDebugRequest(r, path)
 	out, err := s.renderer.RenderURL(graph, path, s.cfg.Server.LiveReload)
+	finishDebug(err, len(out))
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			http.NotFound(w, r)
@@ -488,4 +631,289 @@ func (s *Server) handlePage(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	_, _ = w.Write(out)
+}
+
+func (s *Server) wrapDebugHTTP(next http.Handler) *http.ServeMux {
+	mux := http.NewServeMux()
+	mux.Handle("/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reqID := requestSequence.Add(1)
+		start := time.Now()
+		before := s.captureRuntimeSnapshot()
+
+		args := []any{
+			"http_request_id", reqID,
+			"method", r.Method,
+			"path", r.URL.Path,
+			"query", r.URL.RawQuery,
+			"remote_addr", r.RemoteAddr,
+			"user_agent", r.UserAgent(),
+		}
+		args = append(args, before.logFields("runtime_")...)
+		args = append(args, s.connectionStateFields("connections_")...)
+		logx.Info("http request started", args...)
+
+		rec := &statusRecorder{ResponseWriter: w, status: http.StatusOK}
+		next.ServeHTTP(rec, r)
+
+		after := s.captureRuntimeSnapshot()
+		finishArgs := []any{
+			"http_request_id", reqID,
+			"method", r.Method,
+			"path", r.URL.Path,
+			"status", rec.status,
+			"bytes", rec.bytes,
+			"elapsed", time.Since(start).String(),
+		}
+		finishArgs = append(finishArgs, after.logFields("runtime_")...)
+		finishArgs = append(finishArgs, after.deltaFields(before, time.Since(start), "delta_")...)
+		finishArgs = append(finishArgs, s.connectionStateFields("connections_")...)
+		logx.Info("http request finished", finishArgs...)
+	}))
+	return mux
+}
+
+func (s *Server) beginDebugRequest(r *http.Request, path string) (uint64, func(error, int)) {
+	if !s.debug {
+		return 0, func(error, int) {}
+	}
+
+	reqID := requestSequence.Add(1)
+	start := time.Now()
+	s.activeReqs.Add(1)
+	before := s.captureRuntimeSnapshot()
+	done := make(chan struct{})
+
+	args := []any{
+		"request_id", reqID,
+		"method", r.Method,
+		"path", path,
+		"remote_addr", r.RemoteAddr,
+	}
+	args = append(args, before.logFields("runtime_")...)
+	args = append(args, s.connectionStateFields("connections_")...)
+	logx.Info("serve request started", args...)
+
+	go func() {
+		ticker := time.NewTicker(slowServeRequestInterval)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-done:
+				return
+			case <-ticker.C:
+				snapshot := s.captureRuntimeSnapshot()
+				args := []any{
+					"request_id", reqID,
+					"path", path,
+					"elapsed", time.Since(start).String(),
+				}
+				args = append(args, snapshot.logFields("runtime_")...)
+				args = append(args, snapshot.deltaFields(before, time.Since(start), "delta_")...)
+				args = append(args, s.connectionStateFields("connections_")...)
+				logx.Warn("serve request still rendering", args...)
+			}
+		}
+	}()
+
+	return reqID, func(err error, bytes int) {
+		close(done)
+		s.activeReqs.Add(-1)
+		after := s.captureRuntimeSnapshot()
+		elapsed := time.Since(start)
+
+		args := []any{
+			"request_id", reqID,
+			"path", path,
+			"elapsed", elapsed.String(),
+			"bytes", bytes,
+		}
+		args = append(args, after.logFields("runtime_")...)
+		args = append(args, after.deltaFields(before, elapsed, "delta_")...)
+		args = append(args, s.connectionStateFields("connections_")...)
+		if err != nil {
+			args = append(args, "error", err)
+		}
+
+		logx.Info("serve request finished", args...)
+	}
+}
+
+func (s *Server) debugHeartbeat(ctx context.Context) {
+	ticker := time.NewTicker(debugHeartbeatInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			snapshot := s.captureRuntimeSnapshot()
+			args := snapshot.logFields("runtime_")
+			args = append(args, s.connectionStateFields("connections_")...)
+			logx.Info("serve debug heartbeat", args...)
+		}
+	}
+}
+
+func (s *Server) onConnState(conn net.Conn, state http.ConnState) {
+	s.connMu.Lock()
+	prev, hadPrev := s.connStates[conn]
+	if state == http.StateClosed || state == http.StateHijacked {
+		delete(s.connStates, conn)
+	} else {
+		s.connStates[conn] = state
+	}
+	snapshot := s.connectionStateSnapshotLocked()
+	s.connMu.Unlock()
+
+	args := []any{
+		"remote_addr", conn.RemoteAddr().String(),
+		"state", state.String(),
+	}
+	if hadPrev {
+		args = append(args, "previous_state", prev.String())
+	}
+	args = append(args, snapshot.logFields("connections_")...)
+	logx.Info("http connection state", args...)
+}
+
+type connectionSnapshot struct {
+	New      int
+	Active   int
+	Idle     int
+	Hijacked int
+	Closed   int
+	Total    int
+}
+
+func (s *Server) connectionStateFields(prefix string) []any {
+	s.connMu.Lock()
+	snapshot := s.connectionStateSnapshotLocked()
+	s.connMu.Unlock()
+	return snapshot.logFields(prefix)
+}
+
+func (s *Server) connectionStateSnapshotLocked() connectionSnapshot {
+	var snapshot connectionSnapshot
+	for _, state := range s.connStates {
+		switch state {
+		case http.StateNew:
+			snapshot.New++
+		case http.StateActive:
+			snapshot.Active++
+		case http.StateIdle:
+			snapshot.Idle++
+		case http.StateHijacked:
+			snapshot.Hijacked++
+		case http.StateClosed:
+			snapshot.Closed++
+		}
+	}
+	snapshot.Total = len(s.connStates)
+	return snapshot
+}
+
+func (s connectionSnapshot) logFields(prefix string) []any {
+	return []any{
+		prefix + "new", s.New,
+		prefix + "active", s.Active,
+		prefix + "idle", s.Idle,
+		prefix + "hijacked", s.Hijacked,
+		prefix + "closed", s.Closed,
+		prefix + "total", s.Total,
+	}
+}
+
+type statusRecorder struct {
+	http.ResponseWriter
+	status int
+	bytes  int
+}
+
+func (r *statusRecorder) WriteHeader(status int) {
+	r.status = status
+	r.ResponseWriter.WriteHeader(status)
+}
+
+func (r *statusRecorder) Write(b []byte) (int, error) {
+	n, err := r.ResponseWriter.Write(b)
+	r.bytes += n
+	return n, err
+}
+
+func (r *statusRecorder) Flush() {
+	if flusher, ok := r.ResponseWriter.(http.Flusher); ok {
+		flusher.Flush()
+	}
+}
+
+func (r *statusRecorder) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	hijacker, ok := r.ResponseWriter.(http.Hijacker)
+	if !ok {
+		return nil, nil, fmt.Errorf("response writer does not support hijacking")
+	}
+	return hijacker.Hijack()
+}
+
+func (r *statusRecorder) Push(target string, opts *http.PushOptions) error {
+	if pusher, ok := r.ResponseWriter.(http.Pusher); ok {
+		return pusher.Push(target, opts)
+	}
+	return http.ErrNotSupported
+}
+
+func (s *Server) captureRuntimeSnapshot() runtimeSnapshot {
+	var mem runtime.MemStats
+	runtime.ReadMemStats(&mem)
+
+	userCPU, systemCPU := processCPUTime()
+
+	return runtimeSnapshot{
+		HeapAllocBytes:   mem.HeapAlloc,
+		HeapInuseBytes:   mem.HeapInuse,
+		StackInuseBytes:  mem.StackInuse,
+		SysBytes:         mem.Sys,
+		NumGC:            mem.NumGC,
+		Goroutines:       runtime.NumGoroutine(),
+		ActiveRequests:   s.activeReqs.Load(),
+		ProcessUserCPU:   userCPU,
+		ProcessSystemCPU: systemCPU,
+	}
+}
+
+func (s runtimeSnapshot) logFields(prefix string) []any {
+	return []any{
+		prefix + "heap_alloc_bytes", s.HeapAllocBytes,
+		prefix + "heap_inuse_bytes", s.HeapInuseBytes,
+		prefix + "stack_inuse_bytes", s.StackInuseBytes,
+		prefix + "sys_bytes", s.SysBytes,
+		prefix + "num_gc", s.NumGC,
+		prefix + "goroutines", s.Goroutines,
+		prefix + "active_requests", s.ActiveRequests,
+		prefix + "process_user_cpu_ms", s.ProcessUserCPU.Milliseconds(),
+		prefix + "process_system_cpu_ms", s.ProcessSystemCPU.Milliseconds(),
+	}
+}
+
+func (s runtimeSnapshot) deltaFields(before runtimeSnapshot, elapsed time.Duration, prefix string) []any {
+	userDelta := s.ProcessUserCPU - before.ProcessUserCPU
+	systemDelta := s.ProcessSystemCPU - before.ProcessSystemCPU
+	totalCPUPercent := 0.0
+	if elapsed > 0 {
+		totalCPUPercent = (float64(userDelta+systemDelta) / float64(elapsed)) * 100
+	}
+
+	return []any{
+		prefix + "heap_alloc_bytes", int64(s.HeapAllocBytes) - int64(before.HeapAllocBytes),
+		prefix + "heap_inuse_bytes", int64(s.HeapInuseBytes) - int64(before.HeapInuseBytes),
+		prefix + "stack_inuse_bytes", int64(s.StackInuseBytes) - int64(before.StackInuseBytes),
+		prefix + "sys_bytes", int64(s.SysBytes) - int64(before.SysBytes),
+		prefix + "num_gc", int64(s.NumGC) - int64(before.NumGC),
+		prefix + "goroutines", s.Goroutines - before.Goroutines,
+		prefix + "active_requests", s.ActiveRequests - before.ActiveRequests,
+		prefix + "process_user_cpu_ms", userDelta.Milliseconds(),
+		prefix + "process_system_cpu_ms", systemDelta.Milliseconds(),
+		prefix + "process_cpu_percent", fmt.Sprintf("%.2f", totalCPUPercent),
+	}
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"html/template"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -101,8 +102,14 @@ func TestServerHelpersAndHandlers(t *testing.T) {
 	if !hasRenderableChanges(deps.ChangeSet{Sources: []string{"x"}}) || hasRenderableChanges(deps.ChangeSet{Assets: []string{"x"}}) {
 		t.Fatal("unexpected renderable change detection")
 	}
+	if got := s.reloadVer.Load(); got != 0 {
+		t.Fatalf("expected initial reload version to be zero, got %d", got)
+	}
 	s.signalReload()
 	s.signalReload()
+	if got := s.reloadVer.Load(); got != 2 {
+		t.Fatalf("expected reload version to increment, got %d", got)
+	}
 	select {
 	case <-s.reloadSignal:
 	default:
@@ -232,6 +239,77 @@ func TestServerRebuildIncrementalAndNew(t *testing.T) {
 	}
 }
 
+func TestServerDebugModeOptionAndRequestTracing(t *testing.T) {
+	cfg := testServerConfig(t)
+	writeServerTheme(t, cfg)
+
+	graph := content.NewSiteGraph(cfg)
+	graph.Add(&content.Document{
+		ID:         "page-1",
+		Type:       "page",
+		Lang:       "en",
+		Title:      "About",
+		Slug:       "about",
+		URL:        "/about/",
+		Layout:     "page",
+		SourcePath: filepath.ToSlash(filepath.Join(cfg.ContentDir, "pages", "about.md")),
+	})
+
+	s := New(
+		cfg,
+		stubLoader{graph: graph},
+		router.NewResolver(cfg),
+		renderer.New(cfg, theme.NewManager(cfg.ThemesDir, cfg.Theme), nil),
+		&hookRecorder{},
+		false,
+		WithDebugMode(true),
+	)
+	if !s.debug {
+		t.Fatal("expected debug mode to be enabled")
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/about", nil)
+	req.RemoteAddr = "127.0.0.1:10000"
+	reqID, finish := s.beginDebugRequest(req, "/about/")
+	if reqID == 0 {
+		t.Fatal("expected debug request id")
+	}
+	finish(nil, 128)
+
+	reqID, finish = (&Server{}).beginDebugRequest(req, "/about/")
+	if reqID != 0 {
+		t.Fatalf("expected non-debug request id to be zero, got %d", reqID)
+	}
+	finish(nil, 0)
+}
+
+func TestRuntimeSnapshotFields(t *testing.T) {
+	s := &Server{}
+	before := s.captureRuntimeSnapshot()
+	after := s.captureRuntimeSnapshot()
+
+	fields := after.logFields("runtime_")
+	if len(fields) == 0 {
+		t.Fatal("expected runtime snapshot fields")
+	}
+
+	deltas := after.deltaFields(before, time.Millisecond, "delta_")
+	if len(deltas) == 0 {
+		t.Fatal("expected runtime snapshot delta fields")
+	}
+
+	connA, connB := net.Pipe()
+	defer connA.Close()
+	defer connB.Close()
+	s.connStates = map[net.Conn]http.ConnState{
+		connA: http.StateActive,
+		connB: http.StateIdle,
+	}
+	if got := s.connectionStateFields("connections_"); len(got) == 0 {
+		t.Fatal("expected connection state fields")
+	}
+}
+
 func TestServerErrorAndUnavailablePaths(t *testing.T) {
 	cfg := testServerConfig(t)
 	writeServerTheme(t, cfg)
@@ -285,6 +363,52 @@ func TestServerErrorAndUnavailablePaths(t *testing.T) {
 	s.handleReload(w, httptest.NewRequest(http.MethodGet, "/__reload", nil))
 	if w.status != http.StatusInternalServerError {
 		t.Fatalf("expected reload stream unsupported, got %d", w.status)
+	}
+}
+
+func TestReloadPollEndpointAndVersionParsing(t *testing.T) {
+	s := &Server{}
+
+	rr := httptest.NewRecorder()
+	s.handleReloadPoll(rr, httptest.NewRequest(http.MethodGet, "/__reload/poll", nil))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected poll endpoint OK, got %d", rr.Code)
+	}
+	var initial map[string]any
+	if err := json.Unmarshal(rr.Body.Bytes(), &initial); err != nil {
+		t.Fatalf("decode initial poll response: %v", err)
+	}
+	if initial["reload"] != false {
+		t.Fatalf("expected initial poll response to not request reload, got %#v", initial)
+	}
+
+	s.signalReload()
+	rr = httptest.NewRecorder()
+	s.handleReloadPoll(rr, httptest.NewRequest(http.MethodGet, "/__reload/poll?since=1", nil))
+	var unchanged map[string]any
+	if err := json.Unmarshal(rr.Body.Bytes(), &unchanged); err != nil {
+		t.Fatalf("decode unchanged poll response: %v", err)
+	}
+	if unchanged["reload"] != false {
+		t.Fatalf("expected unchanged poll response to not request reload, got %#v", unchanged)
+	}
+
+	s.signalReload()
+	rr = httptest.NewRecorder()
+	s.handleReloadPoll(rr, httptest.NewRequest(http.MethodGet, "/__reload/poll?since=1", nil))
+	var changed map[string]any
+	if err := json.Unmarshal(rr.Body.Bytes(), &changed); err != nil {
+		t.Fatalf("decode changed poll response: %v", err)
+	}
+	if changed["reload"] != true {
+		t.Fatalf("expected changed poll response to request reload, got %#v", changed)
+	}
+
+	if got := parseReloadVersion(" 42 "); got != 42 {
+		t.Fatalf("expected parsed reload version, got %d", got)
+	}
+	if got := parseReloadVersion("invalid"); got != 0 {
+		t.Fatalf("expected invalid reload version to parse as zero, got %d", got)
 	}
 }
 

--- a/internal/theme/manage.go
+++ b/internal/theme/manage.go
@@ -366,8 +366,77 @@ func scaffoldBase() string {
     {{ if .LiveReload }}
     <script>
       (() => {
+        const mode = '{{ .Site.Server.LiveReloadMode }}' || 'stream';
+
+        if (window.__foundryReloadSource) {
+          window.__foundryReloadSource.close();
+          window.__foundryReloadSource = null;
+        }
+        if (window.__foundryReloadPollTimer) {
+          window.clearTimeout(window.__foundryReloadPollTimer);
+          window.__foundryReloadPollTimer = null;
+        }
+
+        if (mode === 'poll') {
+          const state = { closed: false, version: 0 };
+
+          const close = () => {
+            state.closed = true;
+            if (window.__foundryReloadPollTimer) {
+              window.clearTimeout(window.__foundryReloadPollTimer);
+              window.__foundryReloadPollTimer = null;
+            }
+          };
+
+          const poll = async () => {
+            try {
+              const url = state.version > 0 ? '/__reload/poll?since=' + state.version : '/__reload/poll';
+              const response = await fetch(url, { cache: 'no-store', credentials: 'same-origin' });
+              if (!response.ok) {
+                throw new Error('reload poll failed with status ' + response.status);
+              }
+              const payload = await response.json();
+              if (state.closed) {
+                return;
+              }
+              if (payload && typeof payload.version === 'number') {
+                state.version = payload.version;
+              }
+              if (payload && payload.reload) {
+                close();
+                window.location.reload();
+                return;
+              }
+            } catch (_error) {
+            }
+            if (!state.closed) {
+              window.__foundryReloadPollTimer = window.setTimeout(poll, 1500);
+            }
+          };
+
+          window.addEventListener('pagehide', close, { once: true });
+          window.addEventListener('beforeunload', close, { once: true });
+          void poll();
+          return;
+        }
+
         const es = new EventSource('/__reload');
-        es.onmessage = () => window.location.reload();
+        window.__foundryReloadSource = es;
+
+        const close = () => {
+          if (window.__foundryReloadSource === es) {
+            window.__foundryReloadSource = null;
+          }
+          es.close();
+        };
+
+        es.onmessage = () => {
+          close();
+          window.location.reload();
+        };
+
+        window.addEventListener('pagehide', close, { once: true });
+        window.addEventListener('beforeunload', close, { once: true });
       })();
     </script>
     {{ end }}

--- a/internal/theme/manage_test.go
+++ b/internal/theme/manage_test.go
@@ -82,6 +82,14 @@ func TestThemeManagementErrorsAndHelpers(t *testing.T) {
 		!strings.Contains(scaffoldCSS(), "font-family") {
 		t.Fatal("expected scaffold helper content")
 	}
+	if !strings.Contains(scaffoldBase(), "window.__foundryReloadSource") ||
+		!strings.Contains(scaffoldBase(), "window.__foundryReloadPollTimer") ||
+		!strings.Contains(scaffoldBase(), "/__reload/poll") ||
+		!strings.Contains(scaffoldBase(), "mode === 'poll'") ||
+		!strings.Contains(scaffoldBase(), "pagehide") ||
+		!strings.Contains(scaffoldBase(), "beforeunload") {
+		t.Fatal("expected scaffold base to close live reload connections")
+	}
 }
 
 func TestValidateInstalledRequiresLaunchSlotsInManifestAndTemplates(t *testing.T) {

--- a/themes/default/layouts/base.html
+++ b/themes/default/layouts/base.html
@@ -26,8 +26,77 @@
 {{ if .LiveReload }}
 <script>
     (() => {
+        const mode = '{{ .Site.Server.LiveReloadMode }}' || 'stream';
+
+        if (window.__foundryReloadSource) {
+            window.__foundryReloadSource.close();
+            window.__foundryReloadSource = null;
+        }
+        if (window.__foundryReloadPollTimer) {
+            window.clearTimeout(window.__foundryReloadPollTimer);
+            window.__foundryReloadPollTimer = null;
+        }
+
+        if (mode === 'poll') {
+            const state = { closed: false, version: 0 };
+
+            const close = () => {
+                state.closed = true;
+                if (window.__foundryReloadPollTimer) {
+                    window.clearTimeout(window.__foundryReloadPollTimer);
+                    window.__foundryReloadPollTimer = null;
+                }
+            };
+
+            const poll = async () => {
+                try {
+                    const url = state.version > 0 ? `/__reload/poll?since=${state.version}` : '/__reload/poll';
+                    const response = await fetch(url, { cache: 'no-store', credentials: 'same-origin' });
+                    if (!response.ok) {
+                        throw new Error(`reload poll failed with status ${response.status}`);
+                    }
+                    const payload = await response.json();
+                    if (state.closed) {
+                        return;
+                    }
+                    if (payload && typeof payload.version === 'number') {
+                        state.version = payload.version;
+                    }
+                    if (payload && payload.reload) {
+                        close();
+                        window.location.reload();
+                        return;
+                    }
+                } catch (_error) {
+                }
+                if (!state.closed) {
+                    window.__foundryReloadPollTimer = window.setTimeout(poll, 1500);
+                }
+            };
+
+            window.addEventListener('pagehide', close, { once: true });
+            window.addEventListener('beforeunload', close, { once: true });
+            void poll();
+            return;
+        }
+
         const es = new EventSource('/__reload');
-        es.onmessage = () => window.location.reload();
+        window.__foundryReloadSource = es;
+
+        const close = () => {
+            if (window.__foundryReloadSource === es) {
+                window.__foundryReloadSource = null;
+            }
+            es.close();
+        };
+
+        es.onmessage = () => {
+            close();
+            window.location.reload();
+        };
+
+        window.addEventListener('pagehide', close, { once: true });
+        window.addEventListener('beforeunload', close, { once: true });
     })();
 </script>
 {{ end }}


### PR DESCRIPTION
## Summary

Add polling live reload mode for preview server

## What changed



  - add server.live_reload_mode with stream and poll options
  - default live reload mode to stream and validate allowed config values
  - version reload events in the preview server and add /__reload/poll
  - keep SSE live reload support while adding polling as a safer fallback
  - update default theme and theme scaffold to support both reload transports
  - document live reload modes and when to use polling for local dev stalls
  - add regression tests for config validation, poll endpoint behavior, and theme scaffolding



## Why

Explain the motivation and context for the change.

## Testing

Describe how this was tested.

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `go run ./cmd/plugin-sync`
- [x] Manual testing performed
- [x] Added or updated tests where appropriate

## Screenshots or output

Include screenshots, logs, or terminal output if relevant.

## Checklist

- [x] I have read the contributing guidelines
- [x] I have kept this PR focused in scope
- [x] I have updated documentation if needed
- [x] I have updated generated/plugin-related files if needed
- [x] This change does not introduce known security issues