### PR TITLE
lower go mod v to 1.22

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sphireinc/foundry
 
-go 1.25
+go 1.22
 
 require (
 	github.com/adrg/frontmatter v0.2.0


### PR DESCRIPTION
## Summary

Lower module go version to 1.22


## What changed

  - reduce the go.mod floor from 1.25 to 1.22
  - keep the codebase on the lowest version the current module graph holds cleanly
  - verify the full test suite still passes under the updated module version

## Why

Explain the motivation and context for the change.

## Testing

Describe how this was tested.

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `go run ./cmd/plugin-sync`
- [x] Manual testing performed
- [x] Added or updated tests where appropriate

## Screenshots or output

Include screenshots, logs, or terminal output if relevant.

## Checklist

- [x] I have read the contributing guidelines
- [x] I have kept this PR focused in scope
- [ ] I have updated documentation if needed
- [x] I have updated generated/plugin-related files if needed
- [x] This change does not introduce known security issues