### PR TITLE
modify content lifecycle, add versioning, move from .trash to in-dir …

### DIFF
--- a/internal/admin/service/documents.go
+++ b/internal/admin/service/documents.go
@@ -12,6 +12,7 @@ import (
 	"github.com/sphireinc/foundry/internal/admin/types"
 	"github.com/sphireinc/foundry/internal/content"
 	"github.com/sphireinc/foundry/internal/i18n"
+	"github.com/sphireinc/foundry/internal/lifecycle"
 	"github.com/sphireinc/foundry/internal/markup"
 	"github.com/sphireinc/foundry/internal/safepath"
 	"gopkg.in/yaml.v3"
@@ -97,6 +98,10 @@ func (s *Service) SaveDocument(ctx context.Context, req types.DocumentSaveReques
 	created := false
 	if _, err := s.fs.Stat(sourcePath); err != nil {
 		created = true
+	} else {
+		if err := s.versionFile(sourcePath, time.Now()); err != nil {
+			return nil, err
+		}
 	}
 
 	if err := s.fs.MkdirAll(filepath.Dir(sourcePath), 0o755); err != nil {
@@ -235,23 +240,8 @@ func (s *Service) DeleteDocument(ctx context.Context, req types.DocumentDeleteRe
 		return nil, err
 	}
 
-	contentRoot, err := filepath.Abs(s.cfg.ContentDir)
+	trashPath, err := s.trashFile(sourcePath, time.Now())
 	if err != nil {
-		return nil, err
-	}
-	relPath, err := filepath.Rel(contentRoot, sourcePath)
-	if err != nil {
-		return nil, err
-	}
-	ext := filepath.Ext(relPath)
-	base := strings.TrimSuffix(filepath.Base(relPath), ext)
-	trashDir := filepath.Join(contentRoot, ".trash", filepath.Dir(relPath))
-	trashName := fmt.Sprintf("%s-%s%s", base, time.Now().UTC().Format("20060102T150405"), ext)
-	trashPath := filepath.Join(trashDir, trashName)
-	if err := s.fs.MkdirAll(filepath.Dir(trashPath), 0o755); err != nil {
-		return nil, err
-	}
-	if err := s.fs.Rename(sourcePath, trashPath); err != nil {
 		return nil, err
 	}
 	s.invalidateGraphCache()
@@ -522,6 +512,9 @@ func (s *Service) resolveContentPath(path string) (string, error) {
 	}
 	if filepath.Ext(full) != ".md" {
 		return "", fmt.Errorf("source path must point to a markdown file")
+	}
+	if lifecycle.IsDerivedPath(full) {
+		return "", fmt.Errorf("source path must point to a current markdown file")
 	}
 	if err := ensureNoSymlinkEscape(contentRoot, full); err != nil {
 		return "", err

--- a/internal/admin/service/lifecycle.go
+++ b/internal/admin/service/lifecycle.go
@@ -1,0 +1,112 @@
+package service
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"time"
+
+	"github.com/sphireinc/foundry/internal/lifecycle"
+)
+
+func (s *Service) versionFile(path string, now time.Time) error {
+	if err := lifecycle.ValidateCurrentPath(path); err != nil {
+		return err
+	}
+	if _, err := s.fs.Stat(path); err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	versionPath, err := s.uniqueDerivedPath(func(ts time.Time) string {
+		return lifecycle.BuildVersionPath(path, ts)
+	}, now)
+	if err != nil {
+		return err
+	}
+	if err := s.fs.Rename(path, versionPath); err != nil {
+		return err
+	}
+	return s.pruneVersions(path)
+}
+
+func (s *Service) trashFile(path string, now time.Time) (string, error) {
+	if err := lifecycle.ValidateCurrentPath(path); err != nil {
+		return "", err
+	}
+	if _, err := s.fs.Stat(path); err != nil {
+		return "", err
+	}
+	trashPath, err := s.uniqueDerivedPath(func(ts time.Time) string {
+		return lifecycle.BuildTrashPath(path, ts)
+	}, now)
+	if err != nil {
+		return "", err
+	}
+	if err := s.fs.Rename(path, trashPath); err != nil {
+		return "", err
+	}
+	return trashPath, nil
+}
+
+func (s *Service) pruneVersions(currentPath string) error {
+	maxVersions := s.cfg.Content.MaxVersionsPerFile
+	if maxVersions <= 0 {
+		return nil
+	}
+	dir := filepath.Dir(currentPath)
+	entries, err := s.fs.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+
+	type candidate struct {
+		name string
+		path string
+	}
+	candidates := make([]candidate, 0)
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		fullPath := filepath.Join(dir, entry.Name())
+		original, state, ok := lifecycle.ParsePath(fullPath)
+		if !ok || state != lifecycle.StateVersion {
+			continue
+		}
+		if filepath.Clean(original) != filepath.Clean(currentPath) {
+			continue
+		}
+		candidates = append(candidates, candidate{name: entry.Name(), path: fullPath})
+	}
+	if len(candidates) <= maxVersions {
+		return nil
+	}
+
+	sort.Slice(candidates, func(i, j int) bool {
+		return candidates[i].name > candidates[j].name
+	})
+	for _, candidate := range candidates[maxVersions:] {
+		if err := s.fs.Remove(candidate.path); err != nil && !os.IsNotExist(err) {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *Service) uniqueDerivedPath(build func(time.Time) string, now time.Time) (string, error) {
+	for i := 0; i < 10_000; i++ {
+		candidate := build(now.Add(time.Duration(i) * time.Second))
+		if _, err := s.fs.Stat(candidate); err != nil {
+			if os.IsNotExist(err) {
+				return candidate, nil
+			}
+			return "", err
+		}
+	}
+	return "", os.ErrExist
+}

--- a/internal/admin/service/manage.go
+++ b/internal/admin/service/manage.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/sphireinc/foundry/internal/admin/types"
 	"github.com/sphireinc/foundry/internal/admin/users"
@@ -237,10 +238,11 @@ func (s *Service) DeleteMedia(ctx context.Context, reference string) error {
 	if err != nil {
 		return err
 	}
-	if err := s.fs.Remove(fullPath); err != nil {
+	now := time.Now()
+	if _, err := s.trashFile(fullPath, now); err != nil {
 		return err
 	}
-	if err := s.fs.Remove(mediaMetadataPath(fullPath)); err != nil && !os.IsNotExist(err) {
+	if err := s.trashMediaMetadataForPrimary(fullPath, now); err != nil && !os.IsNotExist(err) {
 		return err
 	}
 	return nil

--- a/internal/admin/service/media.go
+++ b/internal/admin/service/media.go
@@ -9,8 +9,10 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/sphireinc/foundry/internal/admin/types"
+	"github.com/sphireinc/foundry/internal/lifecycle"
 	"github.com/sphireinc/foundry/internal/media"
 	"github.com/sphireinc/foundry/internal/safepath"
 	"gopkg.in/yaml.v3"
@@ -41,7 +43,7 @@ func (s *Service) ListMedia(ctx context.Context) ([]types.MediaItem, error) {
 			if d.IsDir() {
 				return nil
 			}
-			if isMediaMetadataFile(path) {
+			if isMediaMetadataFile(path) || lifecycle.IsDerivedPath(path) {
 				return nil
 			}
 
@@ -146,12 +148,21 @@ func (s *Service) SaveMedia(ctx context.Context, collection, dir, filename, cont
 		return nil, err
 	}
 
-	finalName, created, err := s.nextAvailableFilename(targetDir, safeName)
-	if err != nil {
+	fullPath := filepath.Join(targetDir, safeName)
+	finalName := safeName
+	created := true
+	if _, err := s.fs.Stat(fullPath); err == nil {
+		created = false
+		if err := s.versionFile(fullPath, time.Now()); err != nil {
+			return nil, err
+		}
+		if err := s.versionMediaMetadataForPrimary(fullPath, time.Now()); err != nil {
+			return nil, err
+		}
+	} else if !os.IsNotExist(err) {
 		return nil, err
 	}
 
-	fullPath := filepath.Join(targetDir, finalName)
 	if err := s.fs.WriteFile(fullPath, body, 0o644); err != nil {
 		return nil, err
 	}
@@ -189,10 +200,16 @@ func (s *Service) SaveMediaMetadata(ctx context.Context, reference string, metad
 	metadata = normalizeMediaMetadata(metadata)
 	sidecar := mediaMetadataPath(path)
 	if mediaMetadataEmpty(metadata) {
+		if err := s.versionMediaMetadataForPrimary(path, time.Now()); err != nil {
+			return nil, err
+		}
 		if err := s.fs.Remove(sidecar); err != nil && !os.IsNotExist(err) {
 			return nil, err
 		}
 	} else {
+		if err := s.versionMediaMetadataForPrimary(path, time.Now()); err != nil {
+			return nil, err
+		}
 		body, err := yaml.Marshal(metadata)
 		if err != nil {
 			return nil, err
@@ -231,6 +248,9 @@ func (s *Service) resolveMediaItem(reference string) (types.MediaItem, string, e
 	if err := ensureNoSymlinkEscape(root, fullPath); err != nil {
 		return types.MediaItem{}, "", err
 	}
+	if lifecycle.IsDerivedPath(fullPath) {
+		return types.MediaItem{}, "", fmt.Errorf("media reference must point to a current media file")
+	}
 	info, err := s.fs.Stat(fullPath)
 	if err != nil {
 		return types.MediaItem{}, "", err
@@ -265,6 +285,14 @@ func mediaMetadataPath(path string) string {
 	return path + ".meta.yaml"
 }
 
+func mediaMetadataVersionPath(primaryPath string, now time.Time) string {
+	return lifecycle.BuildVersionPath(primaryPath, now) + ".meta.yaml"
+}
+
+func mediaMetadataTrashPath(primaryPath string, now time.Time) string {
+	return lifecycle.BuildTrashPath(primaryPath, now) + ".meta.yaml"
+}
+
 func isMediaMetadataFile(path string) bool {
 	return strings.HasSuffix(strings.ToLower(path), ".meta.yaml")
 }
@@ -297,6 +325,43 @@ func mediaMetadataEmpty(metadata types.MediaMetadata) bool {
 		len(metadata.Tags) == 0
 }
 
+func (s *Service) versionMediaMetadataForPrimary(primaryPath string, now time.Time) error {
+	sidecar := mediaMetadataPath(primaryPath)
+	if _, err := s.fs.Stat(sidecar); err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	versionPath, err := s.uniqueDerivedPath(func(ts time.Time) string {
+		return mediaMetadataVersionPath(primaryPath, ts)
+	}, now)
+	if err != nil {
+		return err
+	}
+	if err := s.fs.Rename(sidecar, versionPath); err != nil {
+		return err
+	}
+	return s.pruneVersions(sidecar)
+}
+
+func (s *Service) trashMediaMetadataForPrimary(primaryPath string, now time.Time) error {
+	sidecar := mediaMetadataPath(primaryPath)
+	if _, err := s.fs.Stat(sidecar); err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	trashPath, err := s.uniqueDerivedPath(func(ts time.Time) string {
+		return mediaMetadataTrashPath(primaryPath, ts)
+	}, now)
+	if err != nil {
+		return err
+	}
+	return s.fs.Rename(sidecar, trashPath)
+}
+
 func cleanMediaDir(value string) (string, error) {
 	value = strings.TrimSpace(strings.ReplaceAll(value, `\`, "/"))
 	value = strings.Trim(value, "/")
@@ -308,22 +373,4 @@ func cleanMediaDir(value string) (string, error) {
 		return "", fmt.Errorf("invalid media dir: path must stay inside the media root")
 	}
 	return strings.TrimPrefix(cleaned, "/"), nil
-}
-
-func (s *Service) nextAvailableFilename(root, base string) (string, bool, error) {
-	candidate := base
-	ext := filepath.Ext(base)
-	name := strings.TrimSuffix(base, ext)
-	for i := 0; ; i++ {
-		if i > 0 {
-			candidate = fmt.Sprintf("%s-%d%s", name, i+1, ext)
-		}
-		path := filepath.Join(root, candidate)
-		if _, err := s.fs.Stat(path); err != nil {
-			if os.IsNotExist(err) {
-				return candidate, i == 0, nil
-			}
-			return "", false, err
-		}
-	}
 }

--- a/internal/admin/service/service.go
+++ b/internal/admin/service/service.go
@@ -16,6 +16,7 @@ type FileSystem interface {
 	ReadFile(name string) ([]byte, error)
 	WriteFile(name string, data []byte, perm os.FileMode) error
 	Stat(name string) (os.FileInfo, error)
+	ReadDir(name string) ([]os.DirEntry, error)
 	MkdirAll(path string, perm os.FileMode) error
 	Rename(oldpath, newpath string) error
 	Remove(name string) error
@@ -28,6 +29,7 @@ func (osFS) WriteFile(name string, data []byte, perm os.FileMode) error {
 	return os.WriteFile(name, data, perm)
 }
 func (osFS) Stat(name string) (os.FileInfo, error)        { return os.Stat(name) }
+func (osFS) ReadDir(name string) ([]os.DirEntry, error)   { return os.ReadDir(name) }
 func (osFS) MkdirAll(path string, perm os.FileMode) error { return os.MkdirAll(path, perm) }
 func (osFS) Rename(oldpath, newpath string) error         { return os.Rename(oldpath, newpath) }
 func (osFS) Remove(name string) error                     { return os.Remove(name) }

--- a/internal/admin/service/service_test.go
+++ b/internal/admin/service/service_test.go
@@ -61,6 +61,26 @@ func TestSaveDocumentInvalidatesGraphCache(t *testing.T) {
 	if err != nil {
 		t.Fatalf("save document failed: %v", err)
 	}
+	_, err = svc.SaveDocument(context.Background(), types.DocumentSaveRequest{
+		SourcePath: filepath.Join("pages", "cache-test.md"),
+		Raw:        "---\ntitle: Cache Test\nslug: cache-test\n---\n\nUpdated Body",
+	})
+	if err != nil {
+		t.Fatalf("save document second version failed: %v", err)
+	}
+	entries, err := os.ReadDir(filepath.Join(cfg.ContentDir, "pages"))
+	if err != nil {
+		t.Fatalf("read page dir: %v", err)
+	}
+	var foundVersion bool
+	for _, entry := range entries {
+		if strings.HasPrefix(entry.Name(), "cache-test.version.") {
+			foundVersion = true
+		}
+	}
+	if !foundVersion {
+		t.Fatal("expected versioned cache-test document after overwrite")
+	}
 
 	if _, err := svc.load(context.Background(), true); err != nil {
 		t.Fatalf("load after save failed: %v", err)
@@ -282,16 +302,29 @@ func TestMediaUploadAndListing(t *testing.T) {
 	if err != nil {
 		t.Fatalf("save duplicate media: %v", err)
 	}
-	if dupe.Path != "posts/hello/hero-banner-2.png" {
-		t.Fatalf("expected collision suffix, got %#v", dupe)
+	if dupe.Path != "posts/hello/hero-banner.png" || dupe.Created {
+		t.Fatalf("expected overwrite with stable path, got %#v", dupe)
+	}
+	entries, err := os.ReadDir(filepath.Join(cfg.ContentDir, cfg.Content.ImagesDir, "posts", "hello"))
+	if err != nil {
+		t.Fatalf("read media dir: %v", err)
+	}
+	var foundVersion bool
+	for _, entry := range entries {
+		if strings.HasPrefix(entry.Name(), "hero-banner.version.") {
+			foundVersion = true
+		}
+	}
+	if !foundVersion {
+		t.Fatal("expected media overwrite to create versioned file")
 	}
 
 	items, err := svc.ListMedia(context.Background())
 	if err != nil {
 		t.Fatalf("list media: %v", err)
 	}
-	if len(items) != 3 {
-		t.Fatalf("expected 3 media items, got %#v", items)
+	if len(items) != 2 {
+		t.Fatalf("expected 2 current media items, got %#v", items)
 	}
 }
 
@@ -449,7 +482,7 @@ func TestDocumentLifecycleServices(t *testing.T) {
 	if err != nil {
 		t.Fatalf("soft delete document: %v", err)
 	}
-	if deleted.Operation != "soft_delete" || !strings.Contains(deleted.TrashPath, "/.trash/") {
+	if deleted.Operation != "soft_delete" || !strings.Contains(deleted.TrashPath, ".trash.") {
 		t.Fatalf("unexpected delete response: %#v", deleted)
 	}
 	if _, err := os.Stat(createdFullPath); !os.IsNotExist(err) {
@@ -500,12 +533,73 @@ func TestMediaMetadataServices(t *testing.T) {
 	if gotDetail.Metadata.Caption != "System overview" {
 		t.Fatalf("unexpected detail metadata: %#v", gotDetail)
 	}
+	if _, err := svc.SaveMediaMetadata(context.Background(), upload.Reference, types.MediaMetadata{
+		Title: "Updated diagram",
+	}); err != nil {
+		t.Fatalf("update media metadata: %v", err)
+	}
+	entries, err := os.ReadDir(filepath.Join(cfg.ContentDir, cfg.Content.ImagesDir, "posts", "about"))
+	if err != nil {
+		t.Fatalf("read media dir: %v", err)
+	}
+	var foundMetadataVersion bool
+	for _, entry := range entries {
+		if strings.HasPrefix(entry.Name(), "diagram.version.") && strings.HasSuffix(entry.Name(), ".png.meta.yaml") {
+			foundMetadataVersion = true
+		}
+	}
+	if !foundMetadataVersion {
+		t.Fatal("expected metadata update to create versioned sidecar")
+	}
 
 	if err := svc.DeleteMedia(context.Background(), upload.Reference); err != nil {
 		t.Fatalf("delete media: %v", err)
 	}
-	if _, err := os.Stat(filepath.Join(cfg.ContentDir, cfg.Content.ImagesDir, "posts", "about", "diagram.png.meta.yaml")); !os.IsNotExist(err) {
-		t.Fatalf("expected metadata sidecar removal, got err=%v", err)
+	entries, err = os.ReadDir(filepath.Join(cfg.ContentDir, cfg.Content.ImagesDir, "posts", "about"))
+	if err != nil {
+		t.Fatalf("read media dir: %v", err)
+	}
+	var foundTrash, foundSidecarTrash bool
+	for _, entry := range entries {
+		if strings.HasPrefix(entry.Name(), "diagram.trash.") && strings.HasSuffix(entry.Name(), ".png") {
+			foundTrash = true
+		}
+		if strings.HasPrefix(entry.Name(), "diagram.trash.") && strings.HasSuffix(entry.Name(), ".png.meta.yaml") {
+			foundSidecarTrash = true
+		}
+	}
+	if !foundTrash || !foundSidecarTrash {
+		t.Fatalf("expected trashed media and sidecar, got entries %#v", entries)
+	}
+}
+
+func TestVersionRetentionLimit(t *testing.T) {
+	cfg := testServiceConfig(t)
+	cfg.Content.MaxVersionsPerFile = 2
+	svc := New(cfg)
+
+	for i := 0; i < 4; i++ {
+		_, err := svc.SaveDocument(context.Background(), types.DocumentSaveRequest{
+			SourcePath: "pages/retention.md",
+			Raw:        "---\ntitle: Retention\nslug: retention\n---\n\nVersion " + strings.Repeat("x", i+1),
+		})
+		if err != nil {
+			t.Fatalf("save document %d: %v", i, err)
+		}
+	}
+
+	entries, err := os.ReadDir(filepath.Join(cfg.ContentDir, "pages"))
+	if err != nil {
+		t.Fatalf("readdir: %v", err)
+	}
+	var versions int
+	for _, entry := range entries {
+		if strings.HasPrefix(entry.Name(), "retention.version.") {
+			versions++
+		}
+	}
+	if versions != 2 {
+		t.Fatalf("expected 2 retained versions, got %d", versions)
 	}
 }
 

--- a/internal/assets/pipeline.go
+++ b/internal/assets/pipeline.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/sphireinc/foundry/internal/config"
+	"github.com/sphireinc/foundry/internal/lifecycle"
 	"github.com/sphireinc/foundry/internal/safepath"
 )
 
@@ -185,6 +186,9 @@ func listFiles(root, ext string) ([]string, error) {
 		if d.IsDir() {
 			return nil
 		}
+		if shouldSkipAssetPath(path) {
+			return nil
+		}
 		if strings.EqualFold(filepath.Ext(path), ext) {
 			out = append(out, path)
 		}
@@ -230,9 +234,17 @@ func copyDirIfExists(src, dst string) error {
 		if info.IsDir() {
 			return os.MkdirAll(target, 0o755)
 		}
+		if shouldSkipAssetPath(path) {
+			return nil
+		}
 
 		return copyFile(path, target, info.Mode())
 	})
+}
+
+func shouldSkipAssetPath(path string) bool {
+	base := filepath.Base(path)
+	return strings.HasSuffix(strings.ToLower(base), ".meta.yaml") || lifecycle.IsDerivedPath(path)
 }
 
 func copyFile(src, dst string, mode os.FileMode) error {

--- a/internal/assets/pipeline_test.go
+++ b/internal/assets/pipeline_test.go
@@ -17,8 +17,12 @@ func TestSyncCopiesAssetsAndBuildsBundle(t *testing.T) {
 	cfg := testAssetsConfig(t)
 	writeFile(t, filepath.Join(cfg.ContentDir, cfg.Content.AssetsDir, "css", "content.css"), "body { color: red; }")
 	writeFile(t, filepath.Join(cfg.ContentDir, cfg.Content.ImagesDir, "logo.txt"), "img")
+	writeFile(t, filepath.Join(cfg.ContentDir, cfg.Content.ImagesDir, "logo.version.20260319T143209Z.txt"), "old img")
+	writeFile(t, filepath.Join(cfg.ContentDir, cfg.Content.ImagesDir, "logo.trash.20260319T143210Z.txt"), "trashed img")
+	writeFile(t, filepath.Join(cfg.ContentDir, cfg.Content.ImagesDir, "logo.txt.meta.yaml"), "title: Logo")
 	writeFile(t, filepath.Join(cfg.ContentDir, cfg.Content.UploadsDir, "file.txt"), "upload")
 	writeFile(t, filepath.Join(cfg.ThemesDir, cfg.Theme, "assets", "css", "base.css"), "html { color: black; }")
+	writeFile(t, filepath.Join(cfg.ThemesDir, cfg.Theme, "assets", "css", "base.version.20260319T143209Z.css"), "old theme")
 	writeFile(t, filepath.Join(cfg.PluginsDir, "toc", "assets", "toc.css"), ".toc {}")
 
 	hooks := &assetHooks{}
@@ -41,6 +45,14 @@ func TestSyncCopiesAssetsAndBuildsBundle(t *testing.T) {
 		if _, err := os.Stat(filepath.Join(cfg.PublicDir, rel)); err != nil {
 			t.Fatalf("expected copied asset %s: %v", rel, err)
 		}
+	}
+	for _, rel := range []string{"images/logo.version.20260319T143209Z.txt", "images/logo.trash.20260319T143210Z.txt", "images/logo.txt.meta.yaml"} {
+		if _, err := os.Stat(filepath.Join(cfg.PublicDir, rel)); !os.IsNotExist(err) {
+			t.Fatalf("expected derived asset %s to be skipped, err=%v", rel, err)
+		}
+	}
+	if strings.Contains(body, "base.version.20260319T143209Z.css") {
+		t.Fatalf("expected versioned css file to be skipped, got %q", body)
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -65,6 +65,7 @@ type ContentConfig struct {
 	ImagesDir            string `yaml:"images_dir"`
 	AssetsDir            string `yaml:"assets_dir"`
 	UploadsDir           string `yaml:"uploads_dir"`
+	MaxVersionsPerFile   int    `yaml:"max_versions_per_file"`
 	DefaultLayoutPage    string `yaml:"default_layout_page"`
 	DefaultLayoutPost    string `yaml:"default_layout_post"`
 	DefaultPageSlugIndex string `yaml:"default_page_slug_index"`
@@ -184,6 +185,9 @@ func (c *Config) ApplyDefaults() {
 	}
 	if c.Content.UploadsDir == "" {
 		c.Content.UploadsDir = "uploads"
+	}
+	if c.Content.MaxVersionsPerFile <= 0 {
+		c.Content.MaxVersionsPerFile = 10
 	}
 	if c.Content.DefaultLayoutPage == "" {
 		c.Content.DefaultLayoutPage = "page"

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -28,6 +28,9 @@ func TestApplyDefaults(t *testing.T) {
 	if cfg.Admin.SessionTTLMinutes != 30 {
 		t.Fatalf("expected default admin session ttl, got %d", cfg.Admin.SessionTTLMinutes)
 	}
+	if cfg.Content.MaxVersionsPerFile != 10 {
+		t.Fatalf("expected default content max versions, got %d", cfg.Content.MaxVersionsPerFile)
+	}
 	if cfg.Feed.RSSPath == "" || cfg.Feed.SitemapPath == "" {
 		t.Fatalf("expected feed defaults to be set")
 	}

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -35,6 +35,9 @@ func Validate(cfg *Config) []error {
 	require("content.uploads_dir", cfg.Content.UploadsDir)
 	require("content.default_layout_page", cfg.Content.DefaultLayoutPage)
 	require("content.default_layout_post", cfg.Content.DefaultLayoutPost)
+	if cfg.Content.MaxVersionsPerFile <= 0 {
+		errs = append(errs, fmt.Errorf("content.max_versions_per_file must be greater than zero"))
+	}
 
 	require("server.addr", cfg.Server.Addr)
 	require("feed.rss_path", cfg.Feed.RSSPath)

--- a/internal/content/loader.go
+++ b/internal/content/loader.go
@@ -12,6 +12,7 @@ import (
 	"github.com/sphireinc/foundry/internal/data"
 	"github.com/sphireinc/foundry/internal/fields"
 	"github.com/sphireinc/foundry/internal/i18n"
+	"github.com/sphireinc/foundry/internal/lifecycle"
 	"github.com/sphireinc/foundry/internal/markup"
 )
 
@@ -98,7 +99,7 @@ func (l *Loader) loadSection(graph *SiteGraph, docType, root string) error {
 		if err != nil {
 			return fmt.Errorf("walk section: %w", err)
 		}
-		if info.IsDir() || filepath.Ext(path) != ".md" {
+		if info.IsDir() || filepath.Ext(path) != ".md" || lifecycle.IsDerivedPath(path) {
 			return nil
 		}
 

--- a/internal/content/loader_test.go
+++ b/internal/content/loader_test.go
@@ -208,5 +208,11 @@ func testLoaderConfig(t *testing.T) *config.Config {
 	if err := os.WriteFile(filepath.Join(cfg.ContentDir, cfg.Content.PostsDir, "hello.md"), []byte(post), 0o644); err != nil {
 		t.Fatalf("write post: %v", err)
 	}
+	if err := os.WriteFile(filepath.Join(cfg.ContentDir, cfg.Content.PagesDir, "about.version.20260319T143209Z.md"), []byte(page), 0o644); err != nil {
+		t.Fatalf("write page version: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cfg.ContentDir, cfg.Content.PagesDir, "about.trash.20260319T143210Z.md"), []byte(page), 0o644); err != nil {
+		t.Fatalf("write page trash: %v", err)
+	}
 	return cfg
 }

--- a/internal/lifecycle/lifecycle.go
+++ b/internal/lifecycle/lifecycle.go
@@ -1,0 +1,104 @@
+package lifecycle
+
+import (
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+)
+
+const TimestampFormat = "20060102T150405Z"
+
+var derivedStemRE = regexp.MustCompile(`^(.*)\.(version|trash)\.(\d{8}T\d{6}Z)$`)
+
+type State string
+
+const (
+	StateCurrent State = "current"
+	StateVersion State = "version"
+	StateTrash   State = "trash"
+)
+
+func IsDerivedPath(path string) bool {
+	_, _, ok := ParsePath(path)
+	return ok
+}
+
+func IsVersionPath(path string) bool {
+	_, state, ok := ParsePath(path)
+	return ok && state == StateVersion
+}
+
+func IsTrashPath(path string) bool {
+	_, state, ok := ParsePath(path)
+	return ok && state == StateTrash
+}
+
+func ParsePath(path string) (string, State, bool) {
+	dir := filepath.Dir(path)
+	base := filepath.Base(path)
+	stem, ext := splitStemAndExt(base)
+	match := derivedStemRE.FindStringSubmatch(stem)
+	if len(match) != 4 {
+		return "", "", false
+	}
+	original := filepath.Join(dir, match[1]+ext)
+	switch match[2] {
+	case "version":
+		return original, StateVersion, true
+	case "trash":
+		return original, StateTrash, true
+	default:
+		return "", "", false
+	}
+}
+
+func BuildVersionPath(path string, now time.Time) string {
+	return buildDerivedPath(path, "version", now)
+}
+
+func BuildTrashPath(path string, now time.Time) string {
+	return buildDerivedPath(path, "trash", now)
+}
+
+func buildDerivedPath(path, kind string, now time.Time) string {
+	dir := filepath.Dir(path)
+	base := filepath.Base(path)
+	stem, ext := splitStemAndExt(base)
+	if original, _, ok := ParsePath(path); ok {
+		base = filepath.Base(original)
+		stem, ext = splitStemAndExt(base)
+	}
+	return filepath.Join(dir, stem+"."+kind+"."+now.UTC().Format(TimestampFormat)+ext)
+}
+
+func splitStemAndExt(base string) (string, string) {
+	if strings.HasSuffix(base, ".meta.yaml") {
+		core := strings.TrimSuffix(base, ".meta.yaml")
+		ext := filepath.Ext(core)
+		if ext == "" {
+			return core, ".meta.yaml"
+		}
+		return strings.TrimSuffix(core, ext), ext + ".meta.yaml"
+	}
+	ext := filepath.Ext(base)
+	if ext == "" {
+		return base, ""
+	}
+	return strings.TrimSuffix(base, ext), ext
+}
+
+func OriginalPath(path string) string {
+	if original, _, ok := ParsePath(path); ok {
+		return original
+	}
+	return path
+}
+
+func ValidateCurrentPath(path string) error {
+	if IsDerivedPath(path) {
+		return fmt.Errorf("lifecycle-managed derived file paths are not valid current paths: %s", filepath.Base(path))
+	}
+	return nil
+}

--- a/internal/lifecycle/lifecycle_test.go
+++ b/internal/lifecycle/lifecycle_test.go
@@ -1,0 +1,47 @@
+package lifecycle
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestBuildAndParsePaths(t *testing.T) {
+	now := time.Date(2026, 3, 19, 14, 32, 10, 0, time.UTC)
+
+	current := filepath.Join("content", "pages", "about.md")
+	version := BuildVersionPath(current, now)
+	trash := BuildTrashPath(current, now)
+
+	if filepath.ToSlash(version) != "content/pages/about.version.20260319T143210Z.md" {
+		t.Fatalf("unexpected version path: %s", version)
+	}
+	if filepath.ToSlash(trash) != "content/pages/about.trash.20260319T143210Z.md" {
+		t.Fatalf("unexpected trash path: %s", trash)
+	}
+
+	original, state, ok := ParsePath(version)
+	if !ok || state != StateVersion || filepath.ToSlash(original) != filepath.ToSlash(current) {
+		t.Fatalf("unexpected parse version result: %q %q %v", original, state, ok)
+	}
+	original, state, ok = ParsePath(trash)
+	if !ok || state != StateTrash || filepath.ToSlash(original) != filepath.ToSlash(current) {
+		t.Fatalf("unexpected parse trash result: %q %q %v", original, state, ok)
+	}
+}
+
+func TestSidecarPathsPreservePrimaryExtension(t *testing.T) {
+	now := time.Date(2026, 3, 19, 14, 32, 10, 0, time.UTC)
+	current := filepath.Join("content", "images", "hero.png.meta.yaml")
+
+	version := BuildVersionPath(current, now)
+	if filepath.ToSlash(version) != "content/images/hero.version.20260319T143210Z.png.meta.yaml" {
+		t.Fatalf("unexpected sidecar version path: %s", version)
+	}
+	if !IsDerivedPath(version) {
+		t.Fatal("expected derived sidecar path")
+	}
+	if err := ValidateCurrentPath(version); err == nil {
+		t.Fatal("expected derived sidecar to be rejected as current path")
+	}
+}

--- a/internal/media/media.go
+++ b/internal/media/media.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+
+	"github.com/sphireinc/foundry/internal/lifecycle"
 )
 
 type Kind string
@@ -219,6 +221,9 @@ func cleanRelativePath(value string) (string, error) {
 	cleaned = strings.TrimPrefix(cleaned, "/")
 	if cleaned == "" || cleaned == "." {
 		return "", fmt.Errorf("media path cannot be empty")
+	}
+	if lifecycle.IsDerivedPath(cleaned) {
+		return "", fmt.Errorf("media path must reference a current media file")
 	}
 	return cleaned, nil
 }

--- a/internal/media/media_test.go
+++ b/internal/media/media_test.go
@@ -17,6 +17,9 @@ func TestResolveReferenceAndKindDetection(t *testing.T) {
 	if _, err := ResolveReference("media:../escape.png"); err == nil {
 		t.Fatal("expected traversal rejection")
 	}
+	if _, err := ResolveReference("media:images/hero.version.20260319T143209Z.png"); err == nil {
+		t.Fatal("expected derived media reference rejection")
+	}
 	if _, err := ResolveReference("media:videos/demo.mp4"); err == nil {
 		t.Fatal("expected unsupported collection rejection")
 	}


### PR DESCRIPTION
…trash

## Summary

Make content lifecycle better - adds versioning, moves trash from .trash to in-directory soft deleting. 

## What changed

- current files stay in place
- overwrites create *.version.<timestamp>.* files 
- deletes create *.trash.<timestamp>.* files
- media sidecars (metadata files) move in lockstep with their primary file
- loaders and asset/media walkers now ignore derived files and `.meta.yaml`
- bounded version retention is configurable with `content.max_versions_per_file` and defaults to `10`

The shared naming logic lives in `internal/lifecycle/lifecycle.go`. Documents now use in-place version/trash renames in `internal/admin/service/documents.go`, media and sidecar metadata do the same in `internal/admin/
  service/media.go` and `internal/admin/service/manage.go`, and version pruning is handled in `internal/admin/service/lifecycle.go`. Discovery/copy code was updated in `internal/content/loader.go`, `internal/assets/
  pipeline.go`, and `internal/media/media.go`.

coverage added for:

- lifecycle filename parsing
- overwrite version creation
- in-place trash renames
- sidecar metadata version/trash behavior
- retention pruning
- content loader ignoring derived documents
- asset pipeline skipping derived and metadata files

## Why

The change was motivated by a mismatch between Foundrys storage model and the way delete/edit history was being handled originally. My original way of thinking was flawed and would have created divergent methodologies for handling versioning and deletes. 

Foundrys storage model is fundamentally filesystem-native: cntent, media, config, users, and themes all live as files in the repo or project tree. 

The original soft-delete approach, which moved documents into `content/.trash/...` worked, but it started to drift away from that model by creating a parallel trash hierarchy, made recovery less obvious, and didn’t generalize cleanly to media plus sidecar metadata.

At the same time, Foundry had no real version history for edits, so overwriting a document or media file destroyed the previous state immediately.

The new model keeps everything local to the file being managed:

- current file stays at the canonical path
- previous states become *.version.<timestamp>.*
- soft-deleted states become *.trash.<timestamp>.*

That gives a few concrete benefits:

- recovery is simple and manual if needed
- history is visible directly in the same directory as the current file
- the same convention works for documents, media, and media metadata sidecars
- restore/version tooling can later be implemented as renames instead of copy/move workflows
- the system stays easy to reason about without introducing a database or separate revision store

This change aligns lifecycle behavior with Foundrys core design: filesystem-first, explicit, inspectable, auditable and easily reversible.

## Testing

Describe how this was tested.

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `go run ./cmd/plugin-sync`
- [ ] Manual testing performed
- [x] Added or updated tests where appropriate

## Screenshots or output

Include screenshots, logs, or terminal output if relevant.

## Checklist

- [x] I have read the contributing guidelines
- [x] I have kept this PR focused in scope
- [ ] I have updated documentation if needed
- [ ] I have updated generated/plugin-related files if needed
- [ ] This change does not introduce known security issues