### PR TITLE
Adds a managed runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ Foundry-Cloud-API
 Foundry-Cloud-Dashboard
 Foundry-Cloud-Landing
 planning-docs
+.foundry/
 
 
 # Created by https://www.toptal.com/developers/gitignore/api/go,windows,macos,dotenv

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The fastest way to get the project running locally is via Docker:
 docker-compose up
 ```
 
-Otherwise, see the [Getting Started](#getting-started) section for how to install the `foundry` command, and run Foundry locally.
+Otherwise, see the [Getting Started](#getting-started) section for how to install the `foundry` command, run Foundry locally, or run it in portable standalone mode without Docker.
 
 Foundry will run on `http://localhost:8080/` by default, and the admin panel
 is reachable at `http://localhost:8080/__admin`. The default login on a 
@@ -262,6 +262,20 @@ foundry serve
 
 Then open `http://localhost:8080/`.
 
+If you want Foundry to stay running after you close the terminal, use standalone mode:
+
+```bash
+foundry serve-standalone
+foundry status
+foundry logs -f
+foundry stop
+```
+
+Standalone mode stores its runtime files under `.foundry/run/` in the project:
+
+- `standalone.json`
+- `standalone.log`
+
 To produce static output:
 
 ```bash
@@ -287,7 +301,12 @@ foundry build --preview
 foundry build --env preview --target production
 foundry serve
 foundry serve --debug
+foundry serve-standalone
 foundry serve-preview
+foundry status
+foundry restart
+foundry stop
+foundry logs -f
 foundry plugin list --enabled
 foundry theme list
 foundry routes check
@@ -302,6 +321,30 @@ foundry admin hash-password your-password
 4. Reference media from Markdown with the `media:` scheme.
 5. Run `foundry serve` during development.
 6. Run `foundry build` before publishing or checking generated output.
+
+### Standalone mode
+
+For simple self-hosting or local development where you want Foundry to keep running in the background without Docker, use:
+
+```bash
+foundry serve-standalone
+```
+
+Then manage it with:
+
+```bash
+foundry status
+foundry logs
+foundry logs -f
+foundry restart
+foundry stop
+```
+
+Notes:
+
+- standalone mode is designed for macOS and Linux
+- it writes state and logs under `.foundry/run/`
+- it is a portable convenience runtime, not a replacement for Docker, `systemd`, or `launchd` in more serious production setups
 
 Embedded media uses normal Markdown image syntax:
 

--- a/docs/getting-started/index.html
+++ b/docs/getting-started/index.html
@@ -73,7 +73,12 @@ foundry build --preview
 foundry build --env preview --target production
 foundry serve
 foundry serve --debug
+foundry serve-standalone
 foundry serve-preview
+foundry status
+foundry restart
+foundry stop
+foundry logs -f
 foundry plugin list --enabled
 foundry theme list
 foundry routes check
@@ -85,6 +90,13 @@ foundry admin hash-password your-password</code></pre>
             connections, and process CPU time deltas. If <code>admin.debug.pprof</code> is enabled,
             the admin Debug page also surfaces runtime, content, storage, integrity, activity, and
             persisted build-report snapshots alongside authenticated <code>pprof</code> links.
+          </p>
+          <p>
+            If you want Foundry to keep running after the terminal closes, use
+            <code>foundry serve-standalone</code>. Manage that background runtime with
+            <code>foundry status</code>, <code>foundry restart</code>,
+            <code>foundry stop</code>, and <code>foundry logs -f</code>. Foundry stores its
+            runtime files under <code>.foundry/run/</code> in the project root.
           </p>
           <p>
             Live reload supports two transport modes: <code>stream</code> uses Server-Sent-Events

--- a/docs/themes/index.html
+++ b/docs/themes/index.html
@@ -203,7 +203,7 @@ slots:
           <h2>Validation checklist</h2>
           <ol>
             <li>Run <code>foundry theme validate &lt;name&gt;</code>.</li>
-            <li>Preview with <code>foundry serve</code> or <code>foundry serve-preview</code>.</li>
+            <li>Preview with <code>foundry serve</code>, <code>foundry serve-preview</code>, or <code>foundry serve-standalone</code>.</li>
             <li>Confirm page, post, and taxonomy archive templates all render cleanly.</li>
             <li>Check that plugin slots still have sensible placement.</li>
           </ol>

--- a/internal/commands/imports/imports.go
+++ b/internal/commands/imports/imports.go
@@ -13,6 +13,7 @@ import (
 	_ "github.com/sphireinc/foundry/internal/commands/i18n"
 	_ "github.com/sphireinc/foundry/internal/commands/plugin"
 	_ "github.com/sphireinc/foundry/internal/commands/routes"
+	_ "github.com/sphireinc/foundry/internal/commands/standalone"
 	_ "github.com/sphireinc/foundry/internal/commands/theme"
 	_ "github.com/sphireinc/foundry/internal/commands/validate"
 	_ "github.com/sphireinc/foundry/internal/commands/version"

--- a/internal/commands/standalone/standalone.go
+++ b/internal/commands/standalone/standalone.go
@@ -1,0 +1,172 @@
+package standalonecmd
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/sphireinc/foundry/internal/cliout"
+	"github.com/sphireinc/foundry/internal/commands/registry"
+	"github.com/sphireinc/foundry/internal/config"
+	"github.com/sphireinc/foundry/internal/standalone"
+)
+
+type command struct {
+	name    string
+	summary string
+	details []string
+	run     func(*config.Config, []string) error
+}
+
+func (c command) Name() string         { return c.name }
+func (c command) Summary() string      { return c.summary }
+func (c command) Group() string        { return "runtime" }
+func (c command) Details() []string    { return c.details }
+func (c command) RequiresConfig() bool { return false }
+func (c command) Run(cfg *config.Config, args []string) error {
+	return c.run(cfg, args)
+}
+
+func currentProjectDir() (string, error) {
+	return os.Getwd()
+}
+
+func runServeStandalone(_ *config.Config, _ []string) error {
+	projectDir, err := currentProjectDir()
+	if err != nil {
+		return err
+	}
+	state, err := standalone.Start(projectDir, os.Args)
+	if err != nil {
+		return err
+	}
+	cliout.Successf("Foundry standalone server started")
+	fmt.Printf("%s %d\n", cliout.Label("PID:"), state.PID)
+	fmt.Printf("%s %s\n", cliout.Label("Log:"), state.LogPath)
+	fmt.Printf("%s %s\n", cliout.Label("Project:"), state.ProjectDir)
+	return nil
+}
+
+func runStop(_ *config.Config, _ []string) error {
+	projectDir, err := currentProjectDir()
+	if err != nil {
+		return err
+	}
+	if err := standalone.Stop(projectDir); err != nil {
+		return err
+	}
+	cliout.Successf("Foundry standalone server stopped")
+	return nil
+}
+
+func runStatus(_ *config.Config, _ []string) error {
+	projectDir, err := currentProjectDir()
+	if err != nil {
+		return err
+	}
+	state, running, err := standalone.RunningState(projectDir)
+	if err != nil {
+		return err
+	}
+	if state == nil {
+		fmt.Println("not running")
+		return nil
+	}
+	if !running {
+		fmt.Println("not running (stale state found)")
+		fmt.Printf("%s %d\n", cliout.Label("PID:"), state.PID)
+		fmt.Printf("%s %s\n", cliout.Label("Log:"), state.LogPath)
+		return nil
+	}
+	fmt.Println("running")
+	fmt.Printf("%s %d\n", cliout.Label("PID:"), state.PID)
+	fmt.Printf("%s %s\n", cliout.Label("Started:"), state.StartedAt.Local().Format(time.RFC3339))
+	fmt.Printf("%s %s\n", cliout.Label("Log:"), state.LogPath)
+	return nil
+}
+
+func runRestart(_ *config.Config, _ []string) error {
+	projectDir, err := currentProjectDir()
+	if err != nil {
+		return err
+	}
+	state, err := standalone.Restart(projectDir, os.Args)
+	if err != nil {
+		return err
+	}
+	cliout.Successf("Foundry standalone server restarted")
+	fmt.Printf("%s %d\n", cliout.Label("PID:"), state.PID)
+	fmt.Printf("%s %s\n", cliout.Label("Log:"), state.LogPath)
+	return nil
+}
+
+func runLogs(_ *config.Config, args []string) error {
+	projectDir, err := currentProjectDir()
+	if err != nil {
+		return err
+	}
+	paths := standalone.ProjectPaths(projectDir)
+	lines := 120
+	follow := false
+	for _, arg := range args[2:] {
+		switch {
+		case strings.TrimSpace(arg) == "-f" || strings.TrimSpace(arg) == "--follow":
+			follow = true
+		case strings.HasPrefix(strings.TrimSpace(arg), "--lines="):
+			value := strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(arg), "--lines="))
+			n, err := strconv.Atoi(value)
+			if err != nil {
+				return fmt.Errorf("invalid --lines value %q", value)
+			}
+			lines = n
+		default:
+			return fmt.Errorf("usage: foundry logs [--lines=N] [-f|--follow]")
+		}
+	}
+	body, err := standalone.ReadLastLines(paths.LogPath, lines)
+	if err != nil {
+		return err
+	}
+	if body != "" {
+		fmt.Println(body)
+	}
+	if follow {
+		return standalone.FollowLog(paths.LogPath, os.Stdout)
+	}
+	return nil
+}
+
+func init() {
+	registry.Register(command{
+		name:    "serve-standalone",
+		summary: "Run Foundry in the background with PID/log management",
+		details: []string{"foundry serve-standalone", "foundry serve-standalone --debug"},
+		run:     runServeStandalone,
+	})
+	registry.Register(command{
+		name:    "stop",
+		summary: "Stop the standalone Foundry server",
+		details: []string{"foundry stop"},
+		run:     runStop,
+	})
+	registry.Register(command{
+		name:    "status",
+		summary: "Show standalone Foundry server status",
+		details: []string{"foundry status"},
+		run:     runStatus,
+	})
+	registry.Register(command{
+		name:    "restart",
+		summary: "Restart the standalone Foundry server",
+		details: []string{"foundry restart"},
+		run:     runRestart,
+	})
+	registry.Register(command{
+		name:    "logs",
+		summary: "Show standalone Foundry server logs",
+		details: []string{"foundry logs", "foundry logs --lines=200", "foundry logs -f"},
+		run:     runLogs,
+	})
+}

--- a/internal/standalone/process_other.go
+++ b/internal/standalone/process_other.go
@@ -1,0 +1,22 @@
+//go:build !darwin && !linux
+
+package standalone
+
+import (
+	"fmt"
+	"os/exec"
+)
+
+func detachProcess(cmd *exec.Cmd) {}
+
+func IsProcessAlive(pid int) bool {
+	return false
+}
+
+func sendTerminate(pid int) error {
+	return fmt.Errorf("standalone process control is not supported on this platform")
+}
+
+func sendKill(pid int) error {
+	return fmt.Errorf("standalone process control is not supported on this platform")
+}

--- a/internal/standalone/process_unix.go
+++ b/internal/standalone/process_unix.go
@@ -1,0 +1,28 @@
+//go:build darwin || linux
+
+package standalone
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+func detachProcess(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+}
+
+func IsProcessAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	err := syscall.Kill(pid, 0)
+	return err == nil
+}
+
+func sendTerminate(pid int) error {
+	return syscall.Kill(pid, syscall.SIGTERM)
+}
+
+func sendKill(pid int) error {
+	return syscall.Kill(pid, syscall.SIGKILL)
+}

--- a/internal/standalone/standalone.go
+++ b/internal/standalone/standalone.go
@@ -1,0 +1,316 @@
+package standalone
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const (
+	RunDirName   = ".foundry/run"
+	StateFile    = "standalone.json"
+	LogFile      = "standalone.log"
+	defaultLines = 120
+)
+
+type State struct {
+	PID        int       `json:"pid"`
+	StartedAt  time.Time `json:"started_at"`
+	ProjectDir string    `json:"project_dir"`
+	LogPath    string    `json:"log_path"`
+	Command    []string  `json:"command"`
+}
+
+type Paths struct {
+	RunDir    string
+	StatePath string
+	LogPath   string
+}
+
+func ProjectPaths(projectDir string) Paths {
+	runDir := filepath.Join(projectDir, RunDirName)
+	return Paths{
+		RunDir:    runDir,
+		StatePath: filepath.Join(runDir, StateFile),
+		LogPath:   filepath.Join(runDir, LogFile),
+	}
+}
+
+func EnsureRunDir(projectDir string) (Paths, error) {
+	paths := ProjectPaths(projectDir)
+	if err := os.MkdirAll(paths.RunDir, 0o755); err != nil {
+		return Paths{}, err
+	}
+	return paths, nil
+}
+
+func LoadState(projectDir string) (*State, error) {
+	paths := ProjectPaths(projectDir)
+	body, err := os.ReadFile(paths.StatePath)
+	if err != nil {
+		return nil, err
+	}
+	var state State
+	if err := json.Unmarshal(body, &state); err != nil {
+		return nil, err
+	}
+	return &state, nil
+}
+
+func SaveState(projectDir string, state State) error {
+	paths, err := EnsureRunDir(projectDir)
+	if err != nil {
+		return err
+	}
+	body, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(paths.StatePath, body, 0o644)
+}
+
+func RemoveState(projectDir string) error {
+	paths := ProjectPaths(projectDir)
+	if err := os.Remove(paths.StatePath); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}
+
+func RunningState(projectDir string) (*State, bool, error) {
+	state, err := LoadState(projectDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, false, nil
+		}
+		return nil, false, err
+	}
+	if state.PID > 0 && IsProcessAlive(state.PID) {
+		return state, true, nil
+	}
+	return state, false, nil
+}
+
+func Start(projectDir string, rawArgs []string) (*State, error) {
+	if _, running, err := RunningState(projectDir); err != nil {
+		return nil, err
+	} else if running {
+		return nil, fmt.Errorf("Foundry standalone server is already running")
+	}
+
+	command, err := LaunchCommand(projectDir, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	return startWithCommand(projectDir, command)
+}
+
+func startWithCommand(projectDir string, command []string) (*State, error) {
+	if _, running, err := RunningState(projectDir); err != nil {
+		return nil, err
+	} else if running {
+		return nil, fmt.Errorf("Foundry standalone server is already running")
+	}
+
+	paths, err := EnsureRunDir(projectDir)
+	if err != nil {
+		return nil, err
+	}
+	_ = RemoveState(projectDir)
+	if len(command) == 0 {
+		return nil, fmt.Errorf("could not construct standalone launch command")
+	}
+
+	logFile, err := os.OpenFile(paths.LogPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		return nil, err
+	}
+	defer logFile.Close()
+
+	cmd := exec.Command(command[0], command[1:]...)
+	cmd.Dir = projectDir
+	cmd.Stdout = logFile
+	cmd.Stderr = logFile
+	devNull, err := os.Open(os.DevNull)
+	if err == nil {
+		defer devNull.Close()
+		cmd.Stdin = devNull
+	}
+	detachProcess(cmd)
+
+	if err := cmd.Start(); err != nil {
+		return nil, err
+	}
+
+	state := &State{
+		PID:        cmd.Process.Pid,
+		StartedAt:  time.Now().UTC(),
+		ProjectDir: projectDir,
+		LogPath:    paths.LogPath,
+		Command:    append([]string(nil), command...),
+	}
+	if err := SaveState(projectDir, *state); err != nil {
+		return nil, err
+	}
+	return state, nil
+}
+
+func Stop(projectDir string) error {
+	state, running, err := RunningState(projectDir)
+	if err != nil {
+		return err
+	}
+	if state == nil || !running {
+		_ = RemoveState(projectDir)
+		return fmt.Errorf("Foundry standalone server is not running")
+	}
+
+	if err := sendTerminate(state.PID); err != nil {
+		return err
+	}
+	deadline := time.Now().Add(8 * time.Second)
+	for time.Now().Before(deadline) {
+		if !IsProcessAlive(state.PID) {
+			_ = RemoveState(projectDir)
+			return nil
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	if err := sendKill(state.PID); err != nil {
+		return err
+	}
+	_ = RemoveState(projectDir)
+	return nil
+}
+
+func Restart(projectDir string, rawArgs []string) (*State, error) {
+	state, running, err := RunningState(projectDir)
+	if err != nil {
+		return nil, err
+	}
+	command := []string(nil)
+	if state != nil && len(state.Command) > 0 {
+		command = append([]string(nil), state.Command...)
+	}
+	if state != nil && running {
+		if err := Stop(projectDir); err != nil {
+			return nil, err
+		}
+	}
+	if len(command) > 0 {
+		return startWithCommand(projectDir, command)
+	}
+	return Start(projectDir, rawArgs)
+}
+
+func LaunchCommand(projectDir string, rawArgs []string) ([]string, error) {
+	exe, err := os.Executable()
+	if err != nil {
+		return nil, err
+	}
+
+	if shouldUseGoRun(exe, projectDir) {
+		goExe, err := exec.LookPath("go")
+		if err != nil {
+			return nil, fmt.Errorf("foundry was launched via go run but go is not available in PATH")
+		}
+		args := []string{"run", "./cmd/foundry"}
+		raw := append([]string(nil), rawArgs[1:]...)
+		replaced := false
+		for i, arg := range raw {
+			if strings.TrimSpace(arg) == "serve-standalone" {
+				raw[i] = "serve"
+				replaced = true
+				break
+			}
+		}
+		if !replaced {
+			raw = append([]string{"serve"}, raw...)
+		}
+		return append([]string{goExe}, append(args, raw...)...), nil
+	}
+
+	args := append([]string(nil), rawArgs[1:]...)
+	replaced := false
+	for i, arg := range args {
+		if strings.TrimSpace(arg) == "serve-standalone" {
+			args[i] = "serve"
+			replaced = true
+			break
+		}
+	}
+	if !replaced {
+		args = []string{"serve"}
+	}
+	return append([]string{exe}, args...), nil
+}
+
+func shouldUseGoRun(executablePath, projectDir string) bool {
+	exe := filepath.Clean(executablePath)
+	tmp := filepath.Clean(os.TempDir())
+	if strings.Contains(exe, string(filepath.Separator)+"go-build"+string(filepath.Separator)) {
+		return fileExists(filepath.Join(projectDir, "cmd", "foundry", "main.go"))
+	}
+	if strings.HasPrefix(exe, tmp+string(filepath.Separator)) && fileExists(filepath.Join(projectDir, "cmd", "foundry", "main.go")) {
+		return true
+	}
+	return false
+}
+
+func fileExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && !info.IsDir()
+}
+
+func ReadLastLines(path string, lines int) (string, error) {
+	if lines <= 0 {
+		lines = defaultLines
+	}
+	body, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	all := strings.Split(strings.ReplaceAll(string(body), "\r\n", "\n"), "\n")
+	if len(all) > 0 && all[len(all)-1] == "" {
+		all = all[:len(all)-1]
+	}
+	if len(all) > lines {
+		all = all[len(all)-lines:]
+	}
+	return strings.Join(all, "\n"), nil
+}
+
+func FollowLog(path string, out io.Writer) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	if _, err := f.Seek(0, io.SeekEnd); err != nil {
+		return err
+	}
+
+	reader := bufio.NewReader(f)
+	for {
+		line, err := reader.ReadString('\n')
+		if len(line) > 0 {
+			if _, werr := io.WriteString(out, line); werr != nil {
+				return werr
+			}
+		}
+		if err == nil {
+			continue
+		}
+		if err != io.EOF {
+			return err
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+}


### PR DESCRIPTION
## Summary

Describe the purpose of this change.

## What changed

Adds the following commands:

- foundry serve-standalone
- foundry stop
- foundry status
- foundry restart
- foundry logs

What these do:
- runs Foundry in the background on macOS/Linux without Docker
- keeps runtime state under .foundry/run/
- writes:
    - standalone.json
    - standalone.log
- lets you manage the process from Foundry itself instead of using systemd, launchd, or go run ... &

## Why

For running Foundry standalone without Docker - useful for running small tests on 512mb instances without Docker. 

## Testing

Describe how this was tested.

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `go run ./cmd/plugin-sync`
- [ ] Manual testing performed
- [ ] Added or updated tests where appropriate

## Screenshots or output

Include screenshots, logs, or terminal output if relevant.

## Checklist

- [x] I have read the contributing guidelines
- [x] I have kept this PR focused in scope
- [ ] I have updated documentation if needed
- [ ] I have updated generated/plugin-related files if needed
- [ ] This change does not introduce known security issues