### PR TITLE
non-admin user creation bug fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,9 @@ Verify the install:
 foundry version
 ```
 
+That prints runtime-aware version metadata, including the current version, commit, build date,
+install mode, target platform, and executable path.
+
 If you are working from a local checkout instead of a global install, you can run:
 
 ```bash

--- a/internal/commands/version/metadata.go
+++ b/internal/commands/version/metadata.go
@@ -1,0 +1,180 @@
+package version
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+	"runtime/debug"
+	"strings"
+	"time"
+
+	"github.com/sphireinc/foundry/internal/installmode"
+)
+
+type Metadata struct {
+	Version       string `json:"version"`
+	Commit        string `json:"commit"`
+	BuiltAt       string `json:"built_at"`
+	GoVersion     string `json:"go_version"`
+	GOOS          string `json:"goos"`
+	GOARCH        string `json:"goarch"`
+	Executable    string `json:"executable"`
+	InstallMode   string `json:"install_mode"`
+	VCSRevision   string `json:"vcs_revision,omitempty"`
+	VCSTime       string `json:"vcs_time,omitempty"`
+	VCSModified   bool   `json:"vcs_modified"`
+	ModuleVersion string `json:"module_version,omitempty"`
+}
+
+func Current(projectDir string) Metadata {
+	meta := Metadata{
+		Version:     normalizeValue(Version, "dev"),
+		Commit:      normalizeValue(Commit, "none"),
+		BuiltAt:     normalizeValue(Date, "unknown"),
+		GoVersion:   runtime.Version(),
+		GOOS:        runtime.GOOS,
+		GOARCH:      runtime.GOARCH,
+		InstallMode: string(installmode.Detect(projectDir)),
+	}
+	if exe, err := os.Executable(); err == nil {
+		meta.Executable = exe
+	}
+
+	if info, ok := debug.ReadBuildInfo(); ok && info != nil {
+		if info.GoVersion != "" {
+			meta.GoVersion = info.GoVersion
+		}
+		if info.Main.Version != "" && info.Main.Version != "(devel)" {
+			meta.ModuleVersion = info.Main.Version
+			if meta.Version == "" {
+				meta.Version = info.Main.Version
+			}
+		}
+		for _, setting := range info.Settings {
+			switch setting.Key {
+			case "vcs.revision":
+				meta.VCSRevision = setting.Value
+				if meta.Commit == "" {
+					meta.Commit = shortRevision(setting.Value)
+				}
+			case "vcs.time":
+				meta.VCSTime = setting.Value
+				if meta.BuiltAt == "" {
+					meta.BuiltAt = setting.Value
+				}
+			case "vcs.modified":
+				meta.VCSModified = setting.Value == "true"
+			}
+		}
+	}
+
+	if meta.Version == "" {
+		meta.Version = gitVersion(projectDir)
+	}
+	if meta.Commit == "" {
+		meta.Commit = gitCommit(projectDir)
+	}
+	if meta.BuiltAt == "" {
+		meta.BuiltAt = gitCommitTime(projectDir)
+	}
+
+	if meta.Version == "" {
+		meta.Version = "dev"
+	}
+	if meta.Commit == "" {
+		meta.Commit = "unknown"
+	}
+	if meta.BuiltAt == "" {
+		meta.BuiltAt = "unknown"
+	}
+	return meta
+}
+
+func (m Metadata) String() string {
+	lines := []string{
+		fmt.Sprintf("Foundry %s", m.Version),
+		fmt.Sprintf("Commit: %s", m.Commit),
+		fmt.Sprintf("Built: %s", m.BuiltAt),
+		fmt.Sprintf("Go: %s", m.GoVersion),
+		fmt.Sprintf("Target: %s/%s", m.GOOS, m.GOARCH),
+		fmt.Sprintf("Install mode: %s", m.InstallMode),
+	}
+	if m.Executable != "" {
+		lines = append(lines, fmt.Sprintf("Executable: %s", m.Executable))
+	}
+	if m.VCSRevision != "" && shortRevision(m.VCSRevision) != m.Commit {
+		lines = append(lines, fmt.Sprintf("VCS revision: %s", m.VCSRevision))
+	}
+	if m.VCSTime != "" && m.VCSTime != m.BuiltAt {
+		lines = append(lines, fmt.Sprintf("VCS time: %s", m.VCSTime))
+	}
+	if m.VCSModified {
+		lines = append(lines, "VCS modified: true")
+	}
+	if m.ModuleVersion != "" && m.ModuleVersion != m.Version {
+		lines = append(lines, fmt.Sprintf("Module version: %s", m.ModuleVersion))
+	}
+	return strings.Join(lines, "\n")
+}
+
+func (m Metadata) ShortString() string {
+	return fmt.Sprintf("Foundry %s (%s)", m.Version, m.Commit)
+}
+
+func (m Metadata) JSON() string {
+	body, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return "{}"
+	}
+	return string(body)
+}
+
+func normalizeValue(v, placeholder string) string {
+	v = strings.TrimSpace(v)
+	if v == "" || v == placeholder {
+		return ""
+	}
+	return v
+}
+
+func shortRevision(v string) string {
+	v = strings.TrimSpace(v)
+	if len(v) > 12 {
+		return v[:12]
+	}
+	return v
+}
+
+func gitVersion(projectDir string) string {
+	return gitOutput(projectDir, "describe", "--tags", "--abbrev=0")
+}
+
+func gitCommit(projectDir string) string {
+	return gitOutput(projectDir, "rev-parse", "--short", "HEAD")
+}
+
+func gitCommitTime(projectDir string) string {
+	value := gitOutput(projectDir, "show", "-s", "--format=%cI", "HEAD")
+	if value == "" {
+		return ""
+	}
+	if _, err := time.Parse(time.RFC3339, value); err != nil {
+		return ""
+	}
+	return value
+}
+
+func gitOutput(projectDir string, args ...string) string {
+	if strings.TrimSpace(projectDir) == "" {
+		return ""
+	}
+	cmd := exec.Command("git", args...)
+	cmd.Dir = projectDir
+	out, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}

--- a/internal/commands/version/version.go
+++ b/internal/commands/version/version.go
@@ -2,7 +2,8 @@ package version
 
 import (
 	"fmt"
-	"runtime"
+	"os"
+	"strings"
 
 	"github.com/sphireinc/foundry/internal/commands/registry"
 	"github.com/sphireinc/foundry/internal/config"
@@ -29,26 +30,53 @@ func (command) Group() string {
 }
 
 func (command) Details() []string {
-	return nil
+	return []string{
+		"foundry version",
+		"foundry version --short",
+		"foundry version --json",
+	}
 }
 
 func (command) RequiresConfig() bool {
 	return false
 }
 
-func (command) Run(_ *config.Config, _ []string) error {
-	fmt.Println(String())
+func (command) Run(_ *config.Config, args []string) error {
+	projectDir, _ := os.Getwd()
+	meta := Current(projectDir)
+	switch outputMode(versionArgs(args)) {
+	case "short":
+		fmt.Println(meta.ShortString())
+	case "json":
+		fmt.Println(meta.JSON())
+	default:
+		fmt.Println(meta.String())
+	}
 	return nil
 }
 
 func String() string {
-	return fmt.Sprintf(
-		"Foundry %s\ncommit: %s\nbuilt: %s\ngo: %s",
-		Version,
-		Commit,
-		Date,
-		runtime.Version(),
-	)
+	projectDir, _ := os.Getwd()
+	return Current(projectDir).String()
+}
+
+func outputMode(args []string) string {
+	for _, arg := range args {
+		switch strings.TrimSpace(arg) {
+		case "--short":
+			return "short"
+		case "--json":
+			return "json"
+		}
+	}
+	return "default"
+}
+
+func versionArgs(args []string) []string {
+	if len(args) <= 2 {
+		return nil
+	}
+	return args[2:]
 }
 
 func init() {

--- a/internal/commands/version/version_test.go
+++ b/internal/commands/version/version_test.go
@@ -11,7 +11,10 @@ func TestCommandMetadataAndString(t *testing.T) {
 		t.Fatalf("unexpected command metadata")
 	}
 	out := String()
-	if !strings.Contains(out, "Foundry") || !strings.Contains(out, "commit:") {
+	if !strings.Contains(out, "Foundry") ||
+		!strings.Contains(out, "Commit:") ||
+		!strings.Contains(out, "Built:") ||
+		!strings.Contains(out, "Install mode:") {
 		t.Fatalf("unexpected version string: %q", out)
 	}
 	if err := cmd.Run(nil, nil); err != nil {

--- a/internal/installmode/installmode.go
+++ b/internal/installmode/installmode.go
@@ -1,0 +1,39 @@
+package installmode
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/sphireinc/foundry/internal/standalone"
+)
+
+type Mode string
+
+const (
+	Standalone Mode = "standalone"
+	Docker     Mode = "docker"
+	Source     Mode = "source"
+	Binary     Mode = "binary"
+	Unknown    Mode = "unknown"
+)
+
+func Detect(projectDir string) Mode {
+	if _, err := os.Stat("/.dockerenv"); err == nil {
+		return Docker
+	}
+	exe, err := os.Executable()
+	if err != nil {
+		return Unknown
+	}
+	cleanExe := filepath.Clean(exe)
+	tmp := filepath.Clean(os.TempDir())
+	if strings.Contains(cleanExe, string(filepath.Separator)+"go-build"+string(filepath.Separator)) ||
+		strings.HasPrefix(cleanExe, tmp+string(filepath.Separator)) {
+		return Source
+	}
+	if state, running, err := standalone.RunningState(projectDir); err == nil && state != nil && running {
+		return Standalone
+	}
+	return Binary
+}

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	versioncmd "github.com/sphireinc/foundry/internal/commands/version"
+	"github.com/sphireinc/foundry/internal/installmode"
 	"github.com/sphireinc/foundry/internal/logx"
 	"github.com/sphireinc/foundry/internal/standalone"
 )
@@ -29,14 +30,14 @@ const (
 	defaultAPIBase = "https://api.github.com"
 )
 
-type InstallMode string
+type InstallMode = installmode.Mode
 
 const (
-	ModeStandalone InstallMode = "standalone"
-	ModeDocker     InstallMode = "docker"
-	ModeSource     InstallMode = "source"
-	ModeBinary     InstallMode = "binary"
-	ModeUnknown    InstallMode = "unknown"
+	ModeStandalone InstallMode = installmode.Standalone
+	ModeDocker     InstallMode = installmode.Docker
+	ModeSource     InstallMode = installmode.Source
+	ModeBinary     InstallMode = installmode.Binary
+	ModeUnknown    InstallMode = installmode.Unknown
 )
 
 type ReleaseInfo struct {
@@ -80,7 +81,8 @@ func Check(ctx context.Context, projectDir string) (*ReleaseInfo, error) {
 		apiBase = defaultAPIBase
 	}
 	mode := DetectInstallMode(projectDir)
-	current := normalizeVersion(versioncmd.Version)
+	currentMeta := versioncmd.Current(projectDir)
+	current := normalizeVersion(currentMeta.Version)
 	logx.Info("updater release check started", "project_dir", projectDir, "repo", repo, "install_mode", mode, "current_version", current)
 	info := &ReleaseInfo{
 		Repo:           repo,
@@ -130,23 +132,7 @@ func Check(ctx context.Context, projectDir string) (*ReleaseInfo, error) {
 }
 
 func DetectInstallMode(projectDir string) InstallMode {
-	if _, err := os.Stat("/.dockerenv"); err == nil {
-		return ModeDocker
-	}
-	exe, err := os.Executable()
-	if err != nil {
-		return ModeUnknown
-	}
-	cleanExe := filepath.Clean(exe)
-	tmp := filepath.Clean(os.TempDir())
-	if strings.Contains(cleanExe, string(filepath.Separator)+"go-build"+string(filepath.Separator)) ||
-		strings.HasPrefix(cleanExe, tmp+string(filepath.Separator)) {
-		return ModeSource
-	}
-	if state, running, err := standalone.RunningState(projectDir); err == nil && state != nil && running {
-		return ModeStandalone
-	}
-	return ModeBinary
+	return InstallMode(installmode.Detect(projectDir))
 }
 
 func ScheduleApply(ctx context.Context, projectDir string) (*ReleaseInfo, error) {

--- a/themes/admin-themes/default/assets/admin.js
+++ b/themes/admin-themes/default/assets/admin.js
@@ -156,8 +156,20 @@ import {
   });
 
   const capabilitySet = () => new Set(state.session?.capabilities || []);
-  const hasCapability = (capability) => !capability || capabilitySet().has(capability);
-  const debugEnabled = () => !!state.capabilityInfo?.features?.pprof;
+  const hasCapability = (capability) => {
+    if (!capability) return true;
+    const set = capabilitySet();
+    return set.has('*') || set.has(capability);
+  };
+  const capabilityInfoHas = (capability) => {
+    if (!capability) return true;
+    if (typeof state.capabilityInfo?.has === 'function') {
+      return state.capabilityInfo.has(capability);
+    }
+    return hasCapability(capability);
+  };
+  const debugEnabled = () =>
+    !!state.capabilityInfo?.features?.pprof && capabilityInfoHas('debug.read');
   const extensionPages = () =>
     (state.adminExtensions.pages || [])
       .filter((page) => page && page.key && hasCapability(page.capability))
@@ -2543,20 +2555,22 @@ import {
         admin.documents.trash(),
         admin.media.list({ q: state.mediaQuery || undefined }),
         admin.media.trash(),
-        admin.users.list(),
-        settingsAPI.getForm(),
-        settingsAPI.getConfig(),
-        settingsAPI.getCustomCSS(),
-        settingsAPI.getSections(),
-        admin.plugins.list(),
-        admin.extensions.getAdminExtensions(),
-        admin.themes.list(),
-        admin.backups.list(),
-        admin.backups.listGit(),
-        admin.operations.get(),
-        admin.operations.logs(),
-        admin.updates.get(),
-        admin.audit.list(),
+        capabilityInfoHas('users.manage') ? admin.users.list() : Promise.resolve([]),
+        capabilityInfoHas('config.manage') ? settingsAPI.getForm() : Promise.resolve(null),
+        capabilityInfoHas('config.manage') ? settingsAPI.getConfig() : Promise.resolve(null),
+        capabilityInfoHas('config.manage') ? settingsAPI.getCustomCSS() : Promise.resolve(null),
+        capabilityInfoHas('dashboard.read') ? settingsAPI.getSections() : Promise.resolve([]),
+        capabilityInfoHas('plugins.manage') ? admin.plugins.list() : Promise.resolve([]),
+        capabilityInfoHas('dashboard.read')
+          ? admin.extensions.getAdminExtensions()
+          : Promise.resolve({ pages: [], widgets: [], slots: [], settings: [] }),
+        capabilityInfoHas('themes.manage') ? admin.themes.list() : Promise.resolve([]),
+        capabilityInfoHas('config.manage') ? admin.backups.list() : Promise.resolve([]),
+        capabilityInfoHas('config.manage') ? admin.backups.listGit() : Promise.resolve([]),
+        capabilityInfoHas('dashboard.read') ? admin.operations.get() : Promise.resolve(null),
+        capabilityInfoHas('dashboard.read') ? admin.operations.logs() : Promise.resolve(null),
+        capabilityInfoHas('dashboard.read') ? admin.updates.get() : Promise.resolve(null),
+        capabilityInfoHas('audit.read') ? admin.audit.list() : Promise.resolve([]),
       ]);
 
       const assignResult = (index, label, onSuccess, fallback) => {

--- a/themes/admin-themes/default/assets/admin/views/platform.js
+++ b/themes/admin-themes/default/assets/admin/views/platform.js
@@ -379,7 +379,7 @@ export const createPlatformViews = ({
       'Operations',
       `<div class="panel-pad stack">
         <div class="cards">
-          <article class="card"><span class="card-label">Current Release</span><strong>${escapeHTML(updateInfo?.current_version || 'unknown')}</strong><span class="card-copy">Running Foundry version.</span></article>
+          <article class="card"><span class="card-label">Current Release</span><strong>${escapeHTML(updateInfo?.current_version || 'unknown')}</strong><span class="card-copy">This is the Foundry version currently running on this site.</span></article>
           <article class="card"><span class="card-label">Latest Release</span><strong>${escapeHTML(updateInfo?.latest_version || 'unknown')}</strong><span class="card-copy">Latest GitHub release.</span></article>
           <article class="card"><span class="card-label">Install Mode</span><strong>${escapeHTML(updateInfo?.install_mode || 'unknown')}</strong><span class="card-copy">Update support depends on deployment mode.</span></article>
           <article class="card"><span class="card-label">Service</span><strong>${operations.service_running ? 'running' : operations.standalone_active ? 'standalone' : 'inactive'}</strong><span class="card-copy">${escapeHTML(operations.service_message || 'No managed service detected.')}</span></article>


### PR DESCRIPTION
## Summary

There was a bug when creating a new non-admin-level user (e.g., editor role), where the admin shell immediately broke after login beccause the bootstrap loader was calling the runtime whenever config:debug/pprof was enabled (which it is by default as of v1.3.5). That route required `debug.read` permission, and `role:editor` do not have that permission, so the shell died and spit out the middleware error "insufficient admin capabilities".

I added a gate in the debug runtime where it now checks that the debug feature is enabled, AND that the user has `debug.read` permission. I also expanded it so that the admin bootstrap only requests role-appropriate data. 

## What changed

- Admin bootstrap does hard permission checks 
- Debug bootstrap loader checks for permission as well

## Why



## Testing

1. `docker compose down`
2. `docker compose up -d --build`
3. Browser: `http://localhost:8080` - OK
4. Browser: `http://localhost:8080/__admin` - OK
5. Login to Admin Panel as `admin:admin` - OK
6. Go to users, change admin password to `AdminAdminAdmin88##` - OK
7. Log out
8. Log back in to `admin:AdminAdminAdmin88##` - OK
9. Go to users, create new user `newuser:NewUserNewUserNewUser8#` - OK
10. Log out of `admin` user
11. Log back in to admin panel as `newuser:NewUserNewUserNewUser8#` - OK
12. Go do `Documents`
13. Edit and save "About page" successfully - OK
14. Create new page "New Page" as `newuser`, **and publish** - OK
15. Create new post "New Post" as `newuser`, **and publish** - OK
16. Go to `http://localhost:8080/posts/new-post/` - OK
17. Go to `http://localhost:8080/new-page/` - OK

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `go run ./cmd/plugin-sync`
- [ ] Manual testing performed
- [ ] Added or updated tests where appropriate

## Screenshots or output

Include screenshots, logs, or terminal output if relevant.

## Checklist

- [ ] I have read the contributing guidelines
- [ ] I have kept this PR focused in scope
- [ ] I have updated documentation if needed
- [ ] I have updated generated/plugin-related files if needed
- [ ] This change does not introduce known security issues