### PR TITLE
split docker files into dev and prod specific, add a helper docker-init.sh script

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,13 +2,20 @@
 .github
 .idea
 .DS_Store
+.foundry
+.cache
+public
 
 docs/coverage
+playwright-report
+test-results
 node_modules
 
 *.log
 *.out
 coverage.*
+assessment-*.txt
+README_SCREENSHOTS.md
 
 bin
 dist

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+# Copy this file to `.env` for local Docker use if you do not want to export
+# environment variables manually.
+
+FOUNDRY_PUBLISH_ADDR=8080
+FOUNDRY_ADMIN_SESSION_SECRET=dev-session-secret-change-me
+FOUNDRY_ADMIN_TOTP_SECRET_KEY=MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,13 +2,28 @@ FROM golang:1.25-alpine AS builder
 
 WORKDIR /src
 
+ARG FOUNDRY_BUILD_VERSION=""
+ARG FOUNDRY_BUILD_COMMIT=""
+ARG FOUNDRY_BUILD_DATE=""
+
 COPY go.mod go.sum ./
 RUN go mod download
 
 COPY . .
 
 RUN go run ./cmd/plugin-sync
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath -ldflags="-s -w" -o /out/foundry ./cmd/foundry
+RUN set -eu; \
+  LDFLAGS="-s -w"; \
+  if [ -n "$FOUNDRY_BUILD_VERSION" ]; then \
+    LDFLAGS="$LDFLAGS -X github.com/sphireinc/foundry/internal/commands/version.Version=$FOUNDRY_BUILD_VERSION"; \
+  fi; \
+  if [ -n "$FOUNDRY_BUILD_COMMIT" ]; then \
+    LDFLAGS="$LDFLAGS -X github.com/sphireinc/foundry/internal/commands/version.Commit=$FOUNDRY_BUILD_COMMIT"; \
+  fi; \
+  if [ -n "$FOUNDRY_BUILD_DATE" ]; then \
+    LDFLAGS="$LDFLAGS -X github.com/sphireinc/foundry/internal/commands/version.Date=$FOUNDRY_BUILD_DATE"; \
+  fi; \
+  CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath -ldflags="$LDFLAGS" -o /out/foundry ./cmd/foundry
 
 FROM alpine:3.20
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN go mod download
 
 COPY . .
 
+RUN go run ./cmd/plugin-sync
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath -ldflags="-s -w" -o /out/foundry ./cmd/foundry
 
 FROM alpine:3.20
@@ -22,9 +23,8 @@ COPY --chown=foundry:foundry data ./data
 COPY --chown=foundry:foundry themes ./themes
 COPY --chown=foundry:foundry plugins ./plugins
 COPY --chown=foundry:foundry sdk ./sdk
-COPY --chown=foundry:foundry public ./public
 
-RUN mkdir -p /app/data/admin /app/public \
+RUN mkdir -p /app/content /app/data/admin /app/themes /app/plugins /app/public /tmp \
   && chown -R foundry:foundry /app
 
 USER foundry

--- a/README.md
+++ b/README.md
@@ -33,13 +33,37 @@ See more of Foundry here: [Foundry Screenshots](README_SCREENSHOTS.md)
 The fastest way to get the project running locally is via Docker:
 
 ```bash
+sh scripts/docker-init.sh
 docker compose up -d --build
 ```
 
-The compose setup bind-mounts the project into the container for source-driven
-development, but keeps `data/` and `public/` on named Docker volumes so the
-runtime can write sessions, admin state, and generated output without host-file
-permission issues.
+The default [docker-compose.yml](/Users/JuanSanchez/WebstormProjects/cms/docker-compose.yml) is local-development oriented:
+
+- it bind-mounts the project source into the container
+- it keeps `data/` and `public/` on named Docker volumes
+- it reads `.env` when present
+- `scripts/docker-init.sh` creates a `.env` file with random local secrets for local use
+
+For a harder production shape, use [docker-compose.prod.yml](/Users/JuanSanchez/WebstormProjects/cms/docker-compose.prod.yml):
+
+```bash
+export FOUNDRY_ADMIN_SESSION_SECRET="$(openssl rand -hex 32)"
+export FOUNDRY_ADMIN_TOTP_SECRET_KEY="$(openssl rand -base64 32)"
+docker compose -f docker-compose.prod.yml up -d --build
+```
+
+The production compose setup:
+
+- uses explicit required secrets
+- runs with a read-only root filesystem
+- drops Linux capabilities
+- enables `no-new-privileges`
+- uses a tmpfs for `/tmp`
+- uses named volumes for `content/`, `themes/`, `plugins/`, `data/`, and `public/`
+
+Before using the production overlay in anything real, update
+`content/config/site.docker.prod.yaml` so `base_url` matches your deployed
+HTTPS origin.
 
 Otherwise, see the [Getting Started](#getting-started) section for how to install the `foundry` command, run Foundry locally, or run it in portable standalone mode without Docker.
 
@@ -344,6 +368,53 @@ title: Home
 ```
 
 ### Run it
+
+#### Docker
+
+Local development with Docker:
+
+```bash
+sh scripts/docker-init.sh
+docker compose up -d --build
+```
+
+That uses:
+
+- [docker-compose.yml](/Users/JuanSanchez/WebstormProjects/cms/docker-compose.yml)
+- [content/config/site.docker.yaml](/Users/JuanSanchez/WebstormProjects/cms/content/config/site.docker.yaml)
+
+The default Docker setup is intentionally development-oriented:
+
+- the project root is bind-mounted into the container
+- `data/` and `public/` stay on named Docker volumes
+- local Docker secrets can live in `.env`
+
+Production-shaped Docker deployment:
+
+```bash
+export FOUNDRY_ADMIN_SESSION_SECRET="$(openssl rand -hex 32)"
+export FOUNDRY_ADMIN_TOTP_SECRET_KEY="$(openssl rand -base64 32)"
+docker compose -f docker-compose.prod.yml up -d --build
+```
+
+That uses:
+
+- [docker-compose.prod.yml](/Users/JuanSanchez/WebstormProjects/cms/docker-compose.prod.yml)
+- [content/config/site.docker.prod.yaml](/Users/JuanSanchez/WebstormProjects/cms/content/config/site.docker.prod.yaml)
+
+The production compose shape is stricter:
+
+- explicit required secrets
+- read-only root filesystem
+- `tmpfs` for `/tmp`
+- `cap_drop: ALL`
+- `no-new-privileges`
+- named volumes for `content/`, `themes/`, `plugins/`, `data/`, and `public/`
+
+Before using the production Docker overlay, set the real HTTPS origin in
+`content/config/site.docker.prod.yaml`.
+
+#### Source / local binary
 
 Start the local preview server from the project root:
 

--- a/README.md
+++ b/README.md
@@ -1028,7 +1028,7 @@ admin:
   single_session_per_user: false
 ```
 
-`admin.local_only` is a convenience restriction for local development. It should not be treated as the only security boundary in front of a reverse proxy.
+`admin.local_only` is an optional convenience restriction for local development. It is not the default posture and should not be treated as the only security boundary in front of a reverse proxy.
 
 The dfault admin theme now includes:
 

--- a/content/config/admin-users.yaml
+++ b/content/config/admin-users.yaml
@@ -4,6 +4,6 @@ users:
       email: admin@example.com
       role: admin
       password_hash: argon2id$65536$3$2$enipjk85SldefbiLo4AAOA$O1Ie6YSGZ4dCxDqnFD6J5tS7BUy244QPUVD0RTIbPJQ
-      totp_secret: RZ2PGU2IJFJ2GGG2FBTHZEDCZZZF34LM
+      totp_secret: enc:v1:Igt1jMsICEWbMEkE7prTtEjZpYyfJoIvzluN8ihKji4wIlotJFdBn9G2YVR5eidM7JmzxjnzzZdNBdAP
       reset_token_hash: pbkdf2-sha256$120000$DJ+JBgxAFXhHnQaYsr8o+Q$kbTFIXGi1HdXJ1AnD0v69z7UYoMi+ctZI5Hyj3tZAR4
       reset_token_expires: 2026-03-21T21:27:22.556821Z

--- a/content/config/example.site.yaml
+++ b/content/config/example.site.yaml
@@ -21,7 +21,7 @@ admin:
   enabled: false
   addr: ""
   path: "/__admin"
-  local_only: true
+  local_only: false
   access_token: ""
   session_secret: ""
   totp_secret_key: ""

--- a/content/config/site.docker.prod.yaml
+++ b/content/config/site.docker.prod.yaml
@@ -1,14 +1,14 @@
-environment: "development"
-base_url: "http://localhost:8080"
+environment: "production"
+base_url: "https://example.com"
 
 server:
   addr: ":8080"
-  live_reload: true
+  live_reload: false
   auto_open_browser: false
   debug_routes: false
 
 admin:
-  local_only: true
+  local_only: false
   debug:
     pprof: false
 

--- a/content/config/site.docker.yaml
+++ b/content/config/site.docker.yaml
@@ -8,9 +8,9 @@ server:
   debug_routes: false
 
 admin:
-  local_only: true
+  local_only: false
   debug:
-    pprof: false
+    pprof: true
 
 backup:
   dir: "data/backups"

--- a/content/config/site.yaml
+++ b/content/config/site.yaml
@@ -19,7 +19,7 @@ admin:
   enabled: true
   addr: ""
   path: "/__admin"
-  local_only: true
+  local_only: false
   access_token: ""
   session_secret: ""
   totp_secret_key: ""

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,40 @@
+services:
+  foundry:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    init: true
+    ports:
+      - "${FOUNDRY_PUBLISH_ADDR:-8080}:8080"
+    environment:
+      FOUNDRY_ADMIN_SESSION_SECRET: "${FOUNDRY_ADMIN_SESSION_SECRET?required}"
+      FOUNDRY_ADMIN_TOTP_SECRET_KEY: "${FOUNDRY_ADMIN_TOTP_SECRET_KEY?required}"
+    volumes:
+      - foundry_content:/app/content
+      - foundry_data:/app/data
+      - foundry_themes:/app/themes
+      - foundry_plugins:/app/plugins
+      - foundry_public:/app/public
+    working_dir: /app
+    command: ["foundry", "--config-overlay", "content/config/site.docker.prod.yaml", "serve"]
+    read_only: true
+    tmpfs:
+      - /tmp:size=64m,noexec,nosuid,nodev
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q -O /dev/null http://127.0.0.1:8080/ || exit 1"]
+      interval: 30s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+    restart: unless-stopped
+
+volumes:
+  foundry_content:
+  foundry_data:
+  foundry_themes:
+  foundry_plugins:
+  foundry_public:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -3,6 +3,10 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+      args:
+        FOUNDRY_BUILD_VERSION: "${FOUNDRY_BUILD_VERSION:-}"
+        FOUNDRY_BUILD_COMMIT: "${FOUNDRY_BUILD_COMMIT:-}"
+        FOUNDRY_BUILD_DATE: "${FOUNDRY_BUILD_DATE:-}"
     init: true
     ports:
       - "${FOUNDRY_PUBLISH_ADDR:-8080}:8080"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,10 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+      args:
+        FOUNDRY_BUILD_VERSION: "${FOUNDRY_BUILD_VERSION:-}"
+        FOUNDRY_BUILD_COMMIT: "${FOUNDRY_BUILD_COMMIT:-}"
+        FOUNDRY_BUILD_DATE: "${FOUNDRY_BUILD_DATE:-}"
     container_name: foundry
     ports:
       - "${FOUNDRY_PUBLISH_ADDR:-8080}:8080"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,12 @@ services:
       dockerfile: Dockerfile
     container_name: foundry
     ports:
-      - "8080:8080"
+      - "${FOUNDRY_PUBLISH_ADDR:-8080}:8080"
+    environment:
+      # Local-development defaults only. Use docker-compose.prod.yml for
+      # hardened deployments with explicit secrets.
+      FOUNDRY_ADMIN_SESSION_SECRET: "${FOUNDRY_ADMIN_SESSION_SECRET:-dev-session-secret-change-me}"
+      FOUNDRY_ADMIN_TOTP_SECRET_KEY: "${FOUNDRY_ADMIN_TOTP_SECRET_KEY:-MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=}"
     volumes:
       - .:/app
       - foundry_data:/app/data

--- a/docs/architecture/index.html
+++ b/docs/architecture/index.html
@@ -23,6 +23,7 @@
         <nav class="nav">
           <a href="../">Home</a>
           <a href="../getting-started/">Getting Started</a>
+          <a href="../docker/">Docker</a>
           <a href="../architecture/">Architecture</a>
           <a href="../config/">Configuration</a>
           <a href="../custom-fields/">Custom Fields</a>

--- a/docs/config/index.html
+++ b/docs/config/index.html
@@ -23,6 +23,7 @@
         <nav class="nav">
           <a href="../">Home</a>
           <a href="../getting-started/">Getting Started</a>
+          <a href="../docker/">Docker</a>
           <a href="../architecture/">Architecture</a>
           <a href="../config/">Configuration</a>
           <a href="../custom-fields/">Custom Fields</a>

--- a/docs/config/index.html
+++ b/docs/config/index.html
@@ -285,7 +285,7 @@ content:
             <li>
               <strong><code>local_only</code></strong
               >: rejects forwarded or non-local admin access when true. <strong>Default: </strong
-              ><code>true</code>.
+              ><code>false</code>.
             </li>
             <li>
               <strong><code>access_token</code></strong
@@ -374,7 +374,7 @@ content:
   enabled: true
   addr: ""
   path: "/__admin"
-  local_only: true
+  local_only: false
   access_token: ""
   session_secret: ""
   totp_secret_key: ""

--- a/docs/contract/index.html
+++ b/docs/contract/index.html
@@ -23,6 +23,7 @@
         <nav class="nav">
           <a href="../">Home</a>
           <a href="../getting-started/">Getting Started</a>
+          <a href="../docker/">Docker</a>
           <a href="../architecture/">Architecture</a>
           <a href="../config/">Configuration</a>
           <a href="../custom-fields/">Custom Fields</a>

--- a/docs/custom-fields/index.html
+++ b/docs/custom-fields/index.html
@@ -23,6 +23,7 @@
         <nav class="nav">
           <a href="../">Home</a>
           <a href="../getting-started/">Getting Started</a>
+          <a href="../docker/">Docker</a>
           <a href="../architecture/">Architecture</a>
           <a href="../config/">Configuration</a>
           <a href="../custom-fields/">Custom Fields</a>

--- a/docs/docker/index.html
+++ b/docs/docker/index.html
@@ -1,0 +1,150 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Foundry Docker Guide</title>
+    <meta
+      name="description"
+      content="How to run Foundry with Docker in local development and in a stricter production-oriented container shape."
+    />
+    <link rel="stylesheet" href="../site.css" />
+  </head>
+  <body>
+    <div class="shell">
+      <header class="topbar">
+        <a class="brand" href="../">
+          <span class="brand-mark"><img src="../logo.png" alt="Foundry logo" /></span>
+          <span class="brand-copy">
+            <strong>Foundry</strong>
+            <span>Docker guide</span>
+          </span>
+        </a>
+        <nav class="nav">
+          <a href="../">Home</a>
+          <a href="../getting-started/">Getting Started</a>
+          <a href="../docker/">Docker</a>
+          <a href="../architecture/">Architecture</a>
+          <a href="../config/">Configuration</a>
+          <a href="../custom-fields/">Custom Fields</a>
+          <a href="../sdk/">SDKs</a>
+          <a href="../plugins/">Plugins</a>
+          <a href="../themes/">Themes</a>
+          <a href="../contract/">CLI Contract</a>
+          <a href="../coverage/">Coverage</a>
+          <a href="https://github.com/sphireinc/foundry">GitHub</a>
+        </nav>
+      </header>
+
+      <main class="content-card">
+        <div class="page-header">
+          <div class="eyebrow">Deployment Guide</div>
+          <h1 class="page-title">Running Foundry with Docker</h1>
+          <p>
+            Foundry ships two Docker Compose shapes: a local-development default and a stricter
+            production-oriented setup. This page explains when to use each one and what each
+            overlay expects.
+          </p>
+        </div>
+
+        <div class="page-body">
+          <h2>Default Docker workflow</h2>
+          <p>
+            The default <code>docker-compose.yml</code> is meant for local development. It keeps
+            the source tree bind-mounted into the container so code, themes, and content edits are
+            reflected immediately.
+          </p>
+          <pre><code>sh scripts/docker-init.sh
+docker compose up -d --build</code></pre>
+          <p>That setup:</p>
+          <ul>
+            <li>bind-mounts the project root into <code>/app</code></li>
+            <li>keeps <code>data/</code> and <code>public/</code> on named Docker volumes</li>
+            <li>uses <code>content/config/site.docker.yaml</code> as the config overlay</li>
+            <li>reads local Docker secrets from <code>.env</code> when present</li>
+            <li>can bootstrap a local <code>.env</code> with <code>scripts/docker-init.sh</code></li>
+          </ul>
+
+          <h2>Local secret bootstrap</h2>
+          <p>
+            <code>scripts/docker-init.sh</code> creates a local <code>.env</code> file if one does
+            not exist and fills in:
+          </p>
+          <ul>
+            <li><code>FOUNDRY_PUBLISH_ADDR</code></li>
+            <li><code>FOUNDRY_ADMIN_SESSION_SECRET</code></li>
+            <li><code>FOUNDRY_ADMIN_TOTP_SECRET_KEY</code></li>
+          </ul>
+          <p>
+            Those values are for local Docker convenience. They are not the production deployment
+            path.
+          </p>
+
+          <h2>Production-oriented Docker workflow</h2>
+          <p>
+            The stricter setup lives in <code>docker-compose.prod.yml</code>. Use it when you want
+            a safer immutable-style container shape instead of a source-mounted development
+            container.
+          </p>
+          <pre><code>export FOUNDRY_ADMIN_SESSION_SECRET="$(openssl rand -hex 32)"
+export FOUNDRY_ADMIN_TOTP_SECRET_KEY="$(openssl rand -base64 32)"
+docker compose -f docker-compose.prod.yml up -d --build</code></pre>
+          <p>That setup:</p>
+          <ul>
+            <li>requires explicit session and TOTP secrets</li>
+            <li>runs with a read-only root filesystem</li>
+            <li>uses <code>tmpfs</code> for <code>/tmp</code></li>
+            <li>drops Linux capabilities</li>
+            <li>enables <code>no-new-privileges</code></li>
+            <li>uses named volumes for <code>content/</code>, <code>themes/</code>, <code>plugins/</code>, <code>data/</code>, and <code>public/</code></li>
+            <li>uses <code>content/config/site.docker.prod.yaml</code> as the config overlay</li>
+          </ul>
+
+          <h2>Important config overlays</h2>
+          <ul>
+            <li>
+              <strong><code>content/config/site.docker.yaml</code></strong>: development-oriented
+              Docker defaults like local base URL and live reload enabled.
+            </li>
+            <li>
+              <strong><code>content/config/site.docker.prod.yaml</code></strong>: production-shaped
+              Docker defaults like disabled live reload, disabled debug surfaces, and explicit
+              production environment labeling.
+            </li>
+          </ul>
+          <p>
+            Before using the production overlay, set
+            <code>content/config/site.docker.prod.yaml</code> <code>base_url</code> to the real
+            HTTPS origin for the deployment.
+          </p>
+
+          <h2>Operational notes</h2>
+          <ul>
+            <li>
+              Set strong values for <code>FOUNDRY_ADMIN_SESSION_SECRET</code> and
+              <code>FOUNDRY_ADMIN_TOTP_SECRET_KEY</code> in production.
+            </li>
+            <li>
+              Keep the production admin behind HTTPS so secure cookies behave correctly.
+            </li>
+            <li>
+              The default Docker setup is convenient for development, but the production compose
+              file is the right base for a real deployment.
+            </li>
+            <li>
+              The Dockerfile creates runtime directories inside the image; generated output belongs
+              on the writable <code>public/</code> volume, not in the image layer.
+            </li>
+          </ul>
+
+          <h2>Related docs</h2>
+          <ul>
+            <li><a href="../getting-started/">Getting Started</a></li>
+            <li><a href="../config/">Configuration</a></li>
+            <li><a href="https://github.com/sphireinc/foundry/blob/main/README.md">README</a></li>
+          </ul>
+        </div>
+      </main>
+    </div>
+  </body>
+</html>

--- a/docs/getting-started/index.html
+++ b/docs/getting-started/index.html
@@ -23,6 +23,7 @@
         <nav class="nav">
           <a href="../">Home</a>
           <a href="../getting-started/">Getting Started</a>
+          <a href="../docker/">Docker</a>
           <a href="../architecture/">Architecture</a>
           <a href="../config/">Configuration</a>
           <a href="../custom-fields/">Custom Fields</a>
@@ -75,10 +76,31 @@
 /docs         GitHub Pages content and generated coverage output</code></pre>
 
           <p>
-            In the Docker Compose setup, Foundry keeps <code>data/</code> and
-            <code>public/</code> on named Docker volumes even though the project root is bind-mounted
-            into the container. That avoids runtime permission failures for admin sessions,
-            audit/state files, and generated output.
+            Foundry ships two Docker shapes. The default
+            <code>docker-compose.yml</code> is local-development oriented: it bind-mounts the
+            project root and keeps <code>data/</code> and <code>public/</code> on named Docker
+            volumes. The stricter <code>docker-compose.prod.yml</code> uses an immutable-style
+            runtime with required secrets, a read-only root filesystem, a tmpfs for
+            <code>/tmp</code>, and named volumes for content, themes, plugins, data, and public
+            output.
+          </p>
+
+          <h2>Docker start</h2>
+          <p>For local Docker development:</p>
+          <pre><code>sh scripts/docker-init.sh
+docker compose up -d --build</code></pre>
+          <p>
+            That bootstraps a local <code>.env</code> file with random Docker secrets if one does
+            not already exist.
+          </p>
+          <p>For the stricter production-oriented Docker shape:</p>
+          <pre><code>export FOUNDRY_ADMIN_SESSION_SECRET="$(openssl rand -hex 32)"
+export FOUNDRY_ADMIN_TOTP_SECRET_KEY="$(openssl rand -base64 32)"
+docker compose -f docker-compose.prod.yml up -d --build</code></pre>
+          <p>
+            Before using the production Docker overlay, update
+            <code>content/config/site.docker.prod.yaml</code> so <code>base_url</code> matches
+            the deployed HTTPS origin.
           </p>
 
           <h2>Common commands</h2>

--- a/docs/index.html
+++ b/docs/index.html
@@ -22,6 +22,7 @@
         <nav class="nav">
           <a href="./">Home</a>
           <a href="./getting-started/">Getting Started</a>
+          <a href="./docker/">Docker</a>
           <a href="./architecture/">Architecture</a>
           <a href="./config/">Configuration</a>
           <a href="./custom-fields/">Custom Fields</a>
@@ -85,6 +86,19 @@
             </div>
           </div>
           <div class="grid">
+            <article class="card">
+              <h3>Docker</h3>
+              <p>
+                How to run Foundry in Docker for local development and with the stricter
+                production-oriented compose setup.
+              </p>
+              <div class="card-links">
+                <a href="./docker/">Open Docker guide</a>
+                <a href="https://github.com/sphireinc/foundry/blob/main/docker-compose.prod.yml"
+                  >Production compose</a
+                >
+              </div>
+            </article>
             <article class="card">
               <h3>Getting Started</h3>
               <p>

--- a/docs/plugins/index.html
+++ b/docs/plugins/index.html
@@ -20,6 +20,7 @@
         <nav class="nav">
           <a href="../">Home</a>
           <a href="../getting-started/">Getting Started</a>
+          <a href="../docker/">Docker</a>
           <a href="../architecture/">Architecture</a>
           <a href="../config/">Configuration</a>
           <a href="../custom-fields/">Custom Fields</a>

--- a/docs/sdk/index.html
+++ b/docs/sdk/index.html
@@ -20,6 +20,7 @@
         <nav class="nav">
           <a href="../">Home</a>
           <a href="../getting-started/">Getting Started</a>
+          <a href="../docker/">Docker</a>
           <a href="../architecture/">Architecture</a>
           <a href="../config/">Configuration</a>
           <a href="../custom-fields/">Custom Fields</a>

--- a/docs/themes/index.html
+++ b/docs/themes/index.html
@@ -20,6 +20,7 @@
         <nav class="nav">
           <a href="../">Home</a>
           <a href="../getting-started/">Getting Started</a>
+          <a href="../docker/">Docker</a>
           <a href="../architecture/">Architecture</a>
           <a href="../config/">Configuration</a>
           <a href="../custom-fields/">Custom Fields</a>

--- a/internal/admin/auth/auth_test.go
+++ b/internal/admin/auth/auth_test.go
@@ -30,7 +30,9 @@ func TestAuthorizeAllowsLocalRequest(t *testing.T) {
 }
 
 func TestAuthorizeRejectsNonLocalRequest(t *testing.T) {
-	m := New(testAuthConfig(t))
+	cfg := testAuthConfig(t)
+	cfg.Admin.LocalOnly = true
+	m := New(cfg)
 	req := httptest.NewRequest("GET", "/__admin/api/status", nil)
 	req.RemoteAddr = "8.8.8.8:12345"
 	req.Header.Set("X-Foundry-Admin-Token", "secret-token")
@@ -41,7 +43,9 @@ func TestAuthorizeRejectsNonLocalRequest(t *testing.T) {
 }
 
 func TestAuthorizeRejectsForwardedLoopbackRequest(t *testing.T) {
-	m := New(testAuthConfig(t))
+	cfg := testAuthConfig(t)
+	cfg.Admin.LocalOnly = true
+	m := New(cfg)
 	req := httptest.NewRequest("GET", "/__admin/api/status", nil)
 	req.RemoteAddr = "127.0.0.1:12345"
 	req.Header.Set("X-Forwarded-For", "8.8.8.8")

--- a/internal/commands/release/release.go
+++ b/internal/commands/release/release.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -71,6 +72,17 @@ func runCut(args []string) error {
 	if err := requireCleanWorktree(); err != nil {
 		return err
 	}
+	if changed, err := updateEmbeddedReleaseVersion(version); err != nil {
+		return err
+	} else if changed {
+		if err := runGit("add", "internal/commands/version/release_version.go"); err != nil {
+			return err
+		}
+		if err := runGit("commit", "-m", "release: embed "+version); err != nil {
+			return err
+		}
+		cliout.Successf("Committed embedded release version %s", version)
+	}
 	if err := ensureTagAbsent(version); err != nil {
 		return err
 	}
@@ -81,16 +93,20 @@ func runCut(args []string) error {
 	cliout.Successf("Created release tag %s", version)
 	fmt.Printf("%s %s\n", cliout.Label("Message:"), message)
 	if push {
+		if err := runGit("push", "origin", "HEAD"); err != nil {
+			return err
+		}
 		if err := runGit("push", "origin", version); err != nil {
 			return err
 		}
 		cliout.Successf("Pushed release tag %s", version)
-		fmt.Println("GitHub Actions will now build and publish the release assets.")
+		fmt.Println("GitHub Actions will now build and publish the release assets from the tagged commit.")
 		return nil
 	}
 	fmt.Println("Next step:")
+	fmt.Println("  git push origin HEAD")
 	fmt.Printf("  git push origin %s\n", version)
-	fmt.Println("That push will trigger the GitHub Release workflow and upload the packaged artifacts.")
+	fmt.Println("Those pushes will trigger the GitHub Release workflow and upload the packaged artifacts.")
 	return nil
 }
 
@@ -164,4 +180,28 @@ func output(name string, args ...string) (string, error) {
 
 func filepathClean(value string) string {
 	return strings.TrimSpace(strings.ReplaceAll(value, "\\", "/"))
+}
+
+func updateEmbeddedReleaseVersion(version string) (bool, error) {
+	const target = "internal/commands/version/release_version.go"
+	body := "package version\n\n" +
+		"// ReleaseVersion is the repo-carried release fallback used when a build does\n" +
+		"// not have Git metadata available, such as container builds from a source\n" +
+		"// archive or a Docker context without .git.\n" +
+		fmt.Sprintf("const ReleaseVersion = %q\n", version)
+
+	current, err := os.ReadFile(target)
+	if err == nil && string(current) == body {
+		return false, nil
+	}
+	if err != nil && !os.IsNotExist(err) {
+		return false, err
+	}
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		return false, err
+	}
+	if err := os.WriteFile(target, []byte(body), 0o644); err != nil {
+		return false, err
+	}
+	return true, nil
 }

--- a/internal/commands/version/release_version.go
+++ b/internal/commands/version/release_version.go
@@ -1,0 +1,6 @@
+package version
+
+// ReleaseVersion is the repo-carried release fallback used when a build does
+// not have Git metadata available, such as container builds from a source
+// archive or a Docker context without .git.
+const ReleaseVersion = "v1.3.9"

--- a/internal/commands/version/version.go
+++ b/internal/commands/version/version.go
@@ -10,10 +10,18 @@ import (
 )
 
 var (
-	Version = "dev"
+	Version = embeddedVersion()
 	Commit  = "none"
 	Date    = "unknown"
 )
+
+func embeddedVersion() string {
+	value := strings.TrimSpace(ReleaseVersion)
+	if value == "" {
+		return "dev"
+	}
+	return value
+}
 
 type command struct{}
 

--- a/internal/commands/version/version_test.go
+++ b/internal/commands/version/version_test.go
@@ -34,3 +34,9 @@ func TestSourceDisplayVersion(t *testing.T) {
 		t.Fatalf("unexpected source display version: %q", got)
 	}
 }
+
+func TestEmbeddedVersionFallback(t *testing.T) {
+	if got := embeddedVersion(); strings.TrimSpace(got) == "" {
+		t.Fatal("expected embedded version fallback to be non-empty")
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -225,8 +225,8 @@ func (c *Config) ApplyDefaults() {
 	if c.Admin.SessionTTLMinutes <= 0 {
 		c.Admin.SessionTTLMinutes = 30
 	}
-	if !c.Admin.localOnlySet && !c.Admin.LocalOnly {
-		c.Admin.LocalOnly = true
+	if !c.Admin.localOnlySet {
+		c.Admin.LocalOnly = false
 	}
 	if c.DefaultLang == "" {
 		c.DefaultLang = "en"

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -16,8 +16,8 @@ func TestApplyDefaults(t *testing.T) {
 	if cfg.Server.LiveReloadMode != "stream" {
 		t.Fatalf("expected live reload mode default to be stream, got %q", cfg.Server.LiveReloadMode)
 	}
-	if cfg.Admin.LocalOnly != true {
-		t.Fatalf("expected admin local only default to be true")
+	if cfg.Admin.LocalOnly != false {
+		t.Fatalf("expected admin local only default to be false")
 	}
 	if cfg.Admin.Theme != "default" {
 		t.Fatalf("expected admin theme default to be default, got %q", cfg.Admin.Theme)

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -87,11 +87,12 @@ func Check(ctx context.Context, projectDir string) (*ReleaseInfo, error) {
 	mode := DetectInstallMode(projectDir)
 	currentMeta := versioncmd.Current(projectDir)
 	current := normalizeVersion(currentMeta.Version)
+	currentDisplay := formatVersion(firstNonEmpty(currentMeta.Version, currentMeta.NearestTag, current))
 	logx.Info("updater release check started", "project_dir", projectDir, "repo", repo, "install_mode", mode, "current_version", current)
 	info := &ReleaseInfo{
 		Repo:                  repo,
-		CurrentVersion:        current,
-		CurrentDisplayVersion: firstNonEmpty(currentMeta.DisplayVersion, currentMeta.Version),
+		CurrentVersion:        currentDisplay,
+		CurrentDisplayVersion: formatVersion(firstNonEmpty(currentMeta.DisplayVersion, currentDisplay)),
 		InstallMode:           mode,
 		NearestTag:            currentMeta.NearestTag,
 		CurrentCommit:         currentMeta.Commit,
@@ -118,7 +119,7 @@ func Check(ctx context.Context, projectDir string) (*ReleaseInfo, error) {
 		return nil, err
 	}
 	latest := normalizeVersion(rel.TagName)
-	info.LatestVersion = latest
+	info.LatestVersion = formatVersion(firstNonEmpty(rel.TagName, latest))
 	info.ReleaseURL = rel.HTMLURL
 	info.Body = rel.Body
 	if ts, err := time.Parse(time.RFC3339, rel.PublishedAt); err == nil {
@@ -325,6 +326,17 @@ func selectAssets(assets []githubAsset) (*githubAsset, *githubAsset) {
 
 func normalizeVersion(v string) string {
 	return strings.TrimPrefix(strings.TrimSpace(v), "v")
+}
+
+func formatVersion(v string) string {
+	v = strings.TrimSpace(v)
+	if v == "" || v == "unknown" || v == "dev" {
+		return v
+	}
+	if strings.HasPrefix(v, "v") {
+		return v
+	}
+	return "v" + v
 }
 
 func compareVersions(a, b string) int {

--- a/scripts/docker-init.sh
+++ b/scripts/docker-init.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+set -eu
+
+ROOT_DIR=$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)
+ENV_FILE="$ROOT_DIR/.env"
+
+random_hex() {
+  openssl rand -hex 32
+}
+
+random_b64() {
+  openssl rand -base64 32 | tr -d '\n'
+}
+
+if [ ! -f "$ENV_FILE" ]; then
+  cat >"$ENV_FILE" <<EOF
+FOUNDRY_PUBLISH_ADDR=8080
+FOUNDRY_ADMIN_SESSION_SECRET=$(random_hex)
+FOUNDRY_ADMIN_TOTP_SECRET_KEY=$(random_b64)
+EOF
+  echo "Created .env with local Docker secrets."
+  exit 0
+fi
+
+append_if_missing() {
+  key=$1
+  value=$2
+  if ! grep -q "^${key}=" "$ENV_FILE"; then
+    printf '%s=%s\n' "$key" "$value" >>"$ENV_FILE"
+  fi
+}
+
+append_if_missing "FOUNDRY_PUBLISH_ADDR" "8080"
+append_if_missing "FOUNDRY_ADMIN_SESSION_SECRET" "$(random_hex)"
+append_if_missing "FOUNDRY_ADMIN_TOTP_SECRET_KEY" "$(random_b64)"
+
+echo ".env already existed; ensured required Docker variables are present."


### PR DESCRIPTION
## Summary

Improves Foundry's Docker story by splitting local-development and production-oriented container workflows, hardening the production shape, and documenting both clearly in the README and published docs.

## What changed

- Split the Docker Compose setup into two explicit paths:
    - `docker-compose.yml` for local development
    - `docker-compose.prod.yml` for a stricter production-oriented runtime
- Updated the container/runtime configuration:
    - removed the brittle public/ copy requirement from the Docker image
    - added `site.docker.yaml` for local Docker defaults
    - added `site.docker.prod.yaml` for production-shaped Docker defaults
    - added `.env.example`
    - added `scripts/docker-init.sh` to bootstrap local Docker secrets
- Hardened the production Compose shape:
    - required explicit admin session and TOTP secrets
    - read-only root filesystem
    - `tmpfs` for `/tmp`
    - `cap_drop: ALL`
    - `no-new-privileges`
    - healthcheck
    - named volumes for `content/`, `themes/`, `plugins/`, `data/`, and `public/`
- Updated docs so the Docker setup is described consistently in:
    - README Quick Start
    - README Getting Started
    - `docs/getting-started/`
    - new dedicated `docs/docker/` guide
    - docs navigation/homepage links

## Why

The previous Docker setup mixed development and production concerns. It assumed generated runtime directories already existed, used a source-mounted shape even when discussing harder deployments, and did not
clearly separate convenience defaults from safer production expectations.

This change gives Foundry a cleaner operational story. Local development stays easy, while production-oriented Docker now has a more appropriate security posture and a dedicated documented path. It also makes
the docs match the actual container setup so users are not left guessing which Compose file or config overlay they should be using.

## Testing

Describe how this was tested.

- [ ] `go test ./...`
- [ ] `go vet ./...`
- [ ] `go run ./cmd/plugin-sync`
- [ ] Manual testing performed
- [ ] Added or updated tests where appropriate

## Screenshots or output

Include screenshots, logs, or terminal output if relevant.

## Checklist

- [ ] I have read the contributing guidelines
- [ ] I have kept this PR focused in scope
- [ ] I have updated documentation if needed
- [ ] I have updated generated/plugin-related files if needed
- [ ] This change does not introduce known security issues