### PR TITLE
Potential fix for code scanning alert no. 12: Size computation for allocation may overflow

### DIFF
--- a/internal/ops/diagnostics.go
+++ b/internal/ops/diagnostics.go
@@ -2,7 +2,6 @@ package ops
 
 import (
 	"fmt"
-	"math"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -36,17 +35,7 @@ type DiagnosticReport struct {
 // Messages flattens all diagnostic categories into a single ordered message
 // slice suitable for CLI output.
 func (r DiagnosticReport) Messages() []string {
-	total := int64(len(r.BrokenMediaRefs)) +
-		int64(len(r.BrokenInternalLinks)) +
-		int64(len(r.MissingTemplates)) +
-		int64(len(r.OrphanedMedia)) +
-		int64(len(r.DuplicateURLs)) +
-		int64(len(r.DuplicateSlugs)) +
-		int64(len(r.TaxonomyInconsistency))
-	if total < 0 || total > int64(math.MaxInt) {
-		total = int64(math.MaxInt)
-	}
-	out := make([]string, 0, int(total))
+	var out []string
 	out = append(out, r.DuplicateURLs...)
 	out = append(out, r.DuplicateSlugs...)
 	out = append(out, r.BrokenMediaRefs...)

--- a/internal/ops/diagnostics.go
+++ b/internal/ops/diagnostics.go
@@ -2,6 +2,7 @@ package ops
 
 import (
 	"fmt"
+	"math"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -35,7 +36,17 @@ type DiagnosticReport struct {
 // Messages flattens all diagnostic categories into a single ordered message
 // slice suitable for CLI output.
 func (r DiagnosticReport) Messages() []string {
-	out := make([]string, 0, len(r.BrokenMediaRefs)+len(r.BrokenInternalLinks)+len(r.MissingTemplates)+len(r.OrphanedMedia)+len(r.DuplicateURLs)+len(r.DuplicateSlugs)+len(r.TaxonomyInconsistency))
+	total := int64(len(r.BrokenMediaRefs)) +
+		int64(len(r.BrokenInternalLinks)) +
+		int64(len(r.MissingTemplates)) +
+		int64(len(r.OrphanedMedia)) +
+		int64(len(r.DuplicateURLs)) +
+		int64(len(r.DuplicateSlugs)) +
+		int64(len(r.TaxonomyInconsistency))
+	if total < 0 || total > int64(math.MaxInt) {
+		total = int64(math.MaxInt)
+	}
+	out := make([]string, 0, int(total))
 	out = append(out, r.DuplicateURLs...)
 	out = append(out, r.DuplicateSlugs...)
 	out = append(out, r.BrokenMediaRefs...)


### PR DESCRIPTION
Potential fix for [https://github.com/sphireinc/Foundry/security/code-scanning/12](https://github.com/sphireinc/Foundry/security/code-scanning/12)

In general, to fix potential size‑computation overflows for allocations, either: (a) validate/limit the sizes of the contributing collections, (b) perform the arithmetic in a wider type (e.g., `uint64`) with explicit checks before converting back to `int`, or (c) avoid precomputing a combined capacity altogether and let Go grow the slice dynamically via `append`.

For this specific case in `DiagnosticReport.Messages`, the simplest and safest fix without changing observable behavior is to avoid computing a potentially overflowing sum of lens and instead grow the output slice incrementally. We can still keep a bounded capacity hint by summing in a wider type and/or by building the slice via successive `append` operations starting from `nil` (or `make([]string, 0, someSafeCap)`). The most straightforward approach is to drop the explicit capacity computation and start with `nil` (or a small fixed capacity); Go will manage growth correctly, and the cost is negligible given that diagnostic reports are not enormous in normal use.

Concretely, in `internal/ops/diagnostics.go`, in the `Messages` method, replace:

```go
out := make([]string, 0, len(r.BrokenMediaRefs)+len(r.BrokenInternalLinks)+len(r.MissingTemplates)+len(r.OrphanedMedia)+len(r.DuplicateURLs)+len(r.DuplicateSlugs)+len(r.TaxonomyInconsistency))
```

with a construction that does not perform this large sum in `int`, e.g.:

```go
out := make([]string, 0, len(r.BrokenMediaRefs)+len(r.BrokenInternalLinks)+len(r.MissingTemplates)+len(r.OrphanedMedia)+len(r.DuplicateURLs)+len(r.DuplicateSlugs)+len(r.TaxonomyInconsistency))
```

but with overflow protection, or more simply:

```go
out := make([]string, 0, len(r.BrokenMediaRefs)+len(r.BrokenInternalLinks)+len(r.MissingTemplates)+len(r.OrphanedMedia)+len(r.DuplicateURLs)+len(r.DuplicateSlugs)+len(r.TaxonomyInconsistency))
```

guarded by computing the total in a wider type and clamping. The cleanest minimal change is to compute the total using `int64`, check against `math.MaxInt`, and then pass a safe `int` to `make`. This preserves the preallocation optimization when safe and avoids overflow, without changing any public API or message contents.

We only need to edit `internal/ops/diagnostics.go`; no new methods or imports beyond `math` are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
