### PR TITLE
Potential fix for code scanning alert no. 81: Cookie 'Secure' attribute is not set to true

### DIFF
--- a/internal/admin/auth/cookie.go
+++ b/internal/admin/auth/cookie.go
@@ -17,7 +17,7 @@ func (m *Middleware) setSessionCookie(w http.ResponseWriter, r *http.Request, to
 		Path:     m.adminPath(),
 		HttpOnly: true,
 		SameSite: http.SameSiteLaxMode,
-		Secure:   requestIsHTTPS(r),
+		Secure:   true,
 		MaxAge:   int(m.SessionTTL().Seconds()),
 	})
 }
@@ -32,7 +32,7 @@ func (m *Middleware) clearSessionCookie(w http.ResponseWriter, r *http.Request) 
 		Path:     m.adminPath(),
 		HttpOnly: true,
 		SameSite: http.SameSiteLaxMode,
-		Secure:   requestIsHTTPS(r),
+		Secure:   true,
 		MaxAge:   -1,
 	})
 }


### PR DESCRIPTION
Potential fix for [https://github.com/sphireinc/Foundry/security/code-scanning/81](https://github.com/sphireinc/Foundry/security/code-scanning/81)

To fix the problem, the session cookie’s `Secure` attribute must be unconditionally set to `true`, rather than depending on the incoming request’s scheme or headers. This ensures that the browser will never send the cookie over an insecure HTTP connection.

Concretely, in `internal/admin/auth/cookie.go`:

- In `setSessionCookie`, change `Secure: requestIsHTTPS(r),` to `Secure: true,`.
- In `clearSessionCookie`, change `Secure: requestIsHTTPS(r),` to `Secure: true,`.

No other behavior needs to change: we keep `HttpOnly`, `SameSite`, `Path`, and `MaxAge` exactly as they are. The helper function `requestIsHTTPS` can remain in place if it’s used elsewhere; we do not need to delete or modify it based on the provided snippet.

No new imports or helper methods are required; we only modify the `Secure` field values in the two cookie constructions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
