### PR TITLE
Potential fix for code scanning alert no. 91: Useless assignment to local variable

### DIFF
--- a/internal/admin/service/history.go
+++ b/internal/admin/service/history.go
@@ -847,8 +847,8 @@ func buildUnifiedLineDiff(leftPath string, leftBody []byte, rightPath string, ri
 	matches := buildLineLCS(leftLines, rightLines)
 
 	var buf bytes.Buffer
-	_, err := fmt.Fprintf(&buf, "--- %s\n", filepath.ToSlash(leftPath))
-	_, err = fmt.Fprintf(&buf, "+++ %s\n", filepath.ToSlash(rightPath))
+	_, _ = fmt.Fprintf(&buf, "--- %s\n", filepath.ToSlash(leftPath))
+	_, err := fmt.Fprintf(&buf, "+++ %s\n", filepath.ToSlash(rightPath))
 	if err != nil {
 		// TODO Handle this error at some point, even if redundant
 	}


### PR DESCRIPTION
Potential fix for [https://github.com/sphireinc/Foundry/security/code-scanning/91](https://github.com/sphireinc/Foundry/security/code-scanning/91)

In general, to fix “useless assignment to local variable” you either remove the unused assignment altogether or replace the variable with the blank identifier `_` so the tool and readers see that the value is intentionally ignored. Here, the function calls `fmt.Fprintf` twice, but only the error from the second call is ever checked. To keep current behavior while satisfying CodeQL and making intent explicit, we should ignore the error from the first `Fprintf` and only bind `err` for the second call, where it is actually used.

Concretely, in `internal/admin/service/history.go` in `buildUnifiedLineDiff`, update line 850 so that it does not introduce or assign to `err` at all, and keep `err` only for the second `Fprintf`. That is, change `_, err := fmt.Fprintf(&buf, "--- %s\n", filepath.ToSlash(leftPath))` to use the blank identifier for the error: `_, _ = fmt.Fprintf(...)`. Then keep line 851 as `_, err := fmt.Fprintf(...)` or `_, err = ...` depending on current scoping; because there is no earlier `err` in this function, we must declare it with `:=` in the second call, and leave the `if err != nil` unchanged. No new imports or helper methods are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
