### PR TITLE
Potential fix for code scanning alert no. 6: Unused variable, import, function or class

### DIFF
--- a/themes/admin-themes/default/assets/admin.js
+++ b/themes/admin-themes/default/assets/admin.js
@@ -216,7 +216,6 @@ import {
   bindGlobalDebugEvents();
 
   const {
-    editorElements,
     setStructuredFields,
     syncStructuredEditorFromRaw,
     syncRawFromStructuredEditor,


### PR DESCRIPTION
Potential fix for [https://github.com/sphireinc/Foundry/security/code-scanning/6](https://github.com/sphireinc/Foundry/security/code-scanning/6)

To fix the problem, we should stop declaring a local variable that is never read. With object destructuring, the standard way to do this is to remove the unused property name from the destructuring pattern, leaving the call and the remaining used properties intact.

Concretely, in `themes/admin-themes/default/assets/admin.js`, locate the `const { ... } = createEditorSync({ ... });` destructuring around line 218–233. Remove `editorElements,` from the destructuring list, leaving the rest (`setStructuredFields`, `syncStructuredEditorFromRaw`, `syncRawFromStructuredEditor`, `insertIntoMarkdown`, `mediaSnippet`, `renderPreviewFrame`) unchanged. No new imports or other code changes are required, and this will not affect runtime behavior because `createEditorSync` is still invoked with the same arguments; we simply stop binding one of its returned properties that wasn’t used.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
