### PR TITLE
Potential fix for code scanning alert no. 90: Writable file handle closed without error handling

### DIFF
--- a/internal/standalone/standalone.go
+++ b/internal/standalone/standalone.go
@@ -127,7 +127,7 @@ func Start(projectDir string, rawArgs []string) (*State, error) {
 	return startWithCommand(projectDir, command)
 }
 
-func startWithCommand(projectDir string, command []string) (*State, error) {
+func startWithCommand(projectDir string, command []string) (state *State, retErr error) {
 	if _, running, err := RunningState(projectDir); err != nil {
 		return nil, err
 	} else if running {
@@ -147,7 +147,11 @@ func startWithCommand(projectDir string, command []string) (*State, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer logFile.Close()
+	defer func() {
+		if err := logFile.Close(); err != nil && retErr == nil {
+			retErr = err
+		}
+	}()
 
 	cmd := exec.Command(command[0], command[1:]...)
 	cmd.Dir = projectDir
@@ -164,7 +168,7 @@ func startWithCommand(projectDir string, command []string) (*State, error) {
 		return nil, err
 	}
 
-	state := &State{
+	state = &State{
 		PID:        cmd.Process.Pid,
 		StartedAt:  time.Now().UTC(),
 		ProjectDir: projectDir,


### PR DESCRIPTION
Potential fix for [https://github.com/sphireinc/Foundry/security/code-scanning/90](https://github.com/sphireinc/Foundry/security/code-scanning/90)

In general, the problem is fixed by ensuring that any writable `*os.File` opened with `os.OpenFile` has its `Close` error checked and handled. When `Close` is deferred, we typically wrap it in a deferred anonymous function capturing a named return error so that any `Close` failure can be propagated or at least logged instead of being silently ignored.

For this specific function, the best fix is to (1) convert `startWithCommand` to use a named error return value, and (2) replace the bare `defer logFile.Close()` with a deferred function that calls `logFile.Close()` and, if it fails and no other error has already been set, assigns that error to the named error return. This preserves existing functionality, only changing behavior when `Close` itself fails. The rest of the logic, including `devNull` and `cmd` handling, remains unchanged. No new imports are required; we only use existing `error` handling.

Concretely:
- Change the signature of `startWithCommand` from `func startWithCommand(projectDir string, command []string) (*State, error)` to `func startWithCommand(projectDir string, command []string) (state *State, retErr error)`.
- Update existing `return` statements to use the named return values where appropriate (e.g., bare `return` at the end, or `return nil, err` where explicit).
- Replace `defer logFile.Close()` with:

  ```go
  defer func() {
      if err := logFile.Close(); err != nil && retErr == nil {
          retErr = err
      }
  }()
  ```

This guarantees that if closing `logFile` fails and no other error has already been returned from `startWithCommand`, the caller will receive the `Close` error.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
