### PR TITLE
Potential fix for code scanning alert no. 89: Writable file handle closed without error handling

### DIFF
--- a/internal/admin/audit/audit.go
+++ b/internal/admin/audit/audit.go
@@ -12,7 +12,7 @@ import (
 	"github.com/sphireinc/foundry/internal/config"
 )
 
-func Log(cfg *config.Config, entry admintypes.AuditEntry) error {
+func Log(cfg *config.Config, entry admintypes.AuditEntry) (logErr error) {
 	if cfg == nil {
 		return nil
 	}
@@ -29,10 +29,15 @@ func Log(cfg *config.Config, entry admintypes.AuditEntry) error {
 	if err != nil {
 		return err
 	}
-	defer f.Close()
+	defer func() {
+		if cerr := f.Close(); logErr == nil && cerr != nil {
+			logErr = cerr
+		}
+	}()
 
 	enc := json.NewEncoder(f)
-	return enc.Encode(entry)
+	logErr = enc.Encode(entry)
+	return
 }
 
 func List(cfg *config.Config, limit int) ([]admintypes.AuditEntry, error) {


### PR DESCRIPTION
Potential fix for [https://github.com/sphireinc/Foundry/security/code-scanning/89](https://github.com/sphireinc/Foundry/security/code-scanning/89)

In general, when working with writable `*os.File` handles, ensure that any error from `Close` (and/or `Sync`) is checked and handled. When `Close` is deferred, this usually means using a named return value and a deferred function that inspects `Close`’s error and updates the return value if appropriate.

For this specific function, the best low-impact fix is to change `Log` to use a named error return and replace `defer f.Close()` with a deferred function that calls `f.Close()` and, if `Close` fails and no earlier error has been set, assigns that error to the named return. That way:
- Current behavior (returning the encoder’s error) is preserved.
- Any `Close` error is surfaced, but only if no previous error was returned.
- No other logic or call sites need to change.

No new imports are needed; we only modify `Log` in `internal/admin/audit/audit.go`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
