### PR TITLE
Adds AI Writer plugin which allows users to generate posts via LLM APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
   <img height="300" src="readme-assets/logo.png" alt="logo">
 </p>
 
-Foundry is a Markdown-first CMS written in Go. It keeps content in files, renders through themes, extends through plugins, and supports both static output and local preview serving.
+Foundry is a Markdown-first CMS written in Go. It keeps content in files, renders through themes, and extends through both first-class compiled Go plugins and out-of-process RPC plugins.
 
 The project is aimed at teams that want a file-based workflow without giving up CMS-style features such as taxonomies, theme-owned custom fields, feeds, plugin hooks, and an admin surface.
 
@@ -22,7 +22,9 @@ See more of Foundry here: [Foundry Screenshots](README_SCREENSHOTS.md)
 - Supports language-aware routing and content grouping
 - Builds a normalized site graph in memory
 - Uses themes for layouts, partials, and theme assets
-- Uses plugins for hooks, asset injection, and runtime extensions
+- Supports first-class compiled Go plugins for deep CMS integration
+- Supports out-of-process RPC plugins for process-isolated extension points
+- Uses plugins for hooks, asset injection, admin pages, and runtime extensions
 - Generates RSS and sitemap output
 - Publishes static output to `public/`
 - Serves the site locally with live reload during development
@@ -1147,7 +1149,12 @@ It also checks:
 
 ## Plugins
 
-Plugins live under `plugins/<name>/` and are registered through generated imports.
+Plugins live under `plugins/<name>/`. Foundry supports two plugin runtime shapes:
+
+- **In-process Go plugins** are compiled into the Foundry binary. They register through Go `init()` functions, so enabling one from the Admin UI only changes config; it cannot import new Go code into an already-built binary. After enabling a newly installed in-process plugin, run `foundry plugin sync` or `go run ./cmd/plugin-sync`, rebuild, and restart.
+- **Out-of-process RPC plugins** declare `runtime.mode: rpc` in `plugin.yaml`. They do not need generated Go imports because Foundry launches the configured command and talks to it through the RPC protocol. The current RPC host supports the context hook family.
+
+Built-in in-process plugins that ship with Foundry may already be compiled into the binary. Locally installed third-party in-process plugins still require generated imports and a rebuild.
 
 Current plugin capabilities include:
 

--- a/content/config/site.yaml
+++ b/content/config/site.yaml
@@ -83,6 +83,8 @@ plugins:
   enabled:
     - readingtime
     - toc
+    - relatedposts
+    - rpc-context-demo
 seo:
   enabled: true
   default_title_sep: "-"

--- a/docs/architecture/index.html
+++ b/docs/architecture/index.html
@@ -84,7 +84,7 @@
             </li>
             <li>
               <strong><code>internal/plugins:</code></strong> plugin metadata, registration,
-              lifecycle hooks, and generated plugin sync.
+              lifecycle hooks, generated plugin sync, and the RPC host for out-of-process plugins.
             </li>
             <li>
               <strong><code>internal/theme:</code></strong> theme management, validation, and
@@ -117,6 +117,14 @@
               Choose between a full rebuild and a targeted rebuild based on the dependency graph.
             </li>
           </ol>
+
+          <h2>Plugin runtime model</h2>
+          <p>
+            Foundry has two plugin runtime paths. First-class Go plugins run in process and are
+            compiled into the binary for deep integration with the CMS lifecycle. RPC plugins run
+            out of process through a declared <code>runtime.mode: rpc</code> command, which lets
+            Foundry expand extension points without loading third-party code into the main process.
+          </p>
 
           <h2>Why the package boundaries matter</h2>
           <p>

--- a/docs/index.html
+++ b/docs/index.html
@@ -41,8 +41,10 @@
             <div class="eyebrow">Project Documentation</div>
             <h1>Foundry.</h1>
             <p>
-              Foundry is a Markdown-first CMS written in Go. Here you can find the project docs, the
-              CLI contract, and the latest HTML coverage report generated from <code>main</code>.
+              Foundry is a Markdown-first CMS written in Go with file-based content, themes,
+              first-class compiled plugins, and out-of-process RPC plugins. Here you can find the
+              project docs, the CLI contract, and the latest HTML coverage report generated from
+              <code>main</code>.
             </p>
             <div class="hero-actions">
               <a class="button" href="./getting-started/">Read the Overview</a>
@@ -51,8 +53,8 @@
             </div>
             <div class="hero-stats">
               <div class="stat">
-                <strong>Documentation</strong>
-                <span>Overview, setup guidance, and the main reference links.</span>
+                <strong>Plugin Runtime</strong>
+                <span>First-class Go plugins and out-of-process RPC plugins.</span>
               </div>
               <div class="stat">
                 <strong>Coverage</strong>
@@ -164,8 +166,8 @@
             <article class="card">
               <h3>Plugin Authoring</h3>
               <p>
-                How to build a plugin, define metadata, register hooks, sync generated imports, and
-                validate the result.
+                How to build first-class Go plugins or out-of-process RPC plugins, define metadata,
+                declare permissions, register hooks, and validate the result.
               </p>
               <div class="card-links">
                 <a href="./plugins/">Open plugin guide</a>

--- a/docs/plugins/index.html
+++ b/docs/plugins/index.html
@@ -343,6 +343,32 @@ permissions:
             </li>
           </ul>
 
+          <h2>In-process vs RPC plugins</h2>
+          <p>
+            Foundry supports two plugin runtime shapes, and they behave differently when installed
+            or enabled.
+          </p>
+          <ul>
+            <li>
+              <strong>In-process Go plugins</strong> are compiled into the Foundry binary. They
+              register through Go <code>init()</code> functions, so enabling one from the Admin UI
+              only changes configuration. It cannot import new Go code into an already-built
+              binary. After enabling a newly installed in-process plugin, run
+              <code>foundry plugin sync</code> or <code>go run ./cmd/plugin-sync</code>, rebuild,
+              and restart.
+            </li>
+            <li>
+              <strong>Out-of-process RPC plugins</strong> declare <code>runtime.mode: rpc</code>
+              in <code>plugin.yaml</code>. They do not need generated Go imports because Foundry
+              launches the configured command and communicates through the RPC protocol.
+            </li>
+          </ul>
+          <p>
+            Built-in in-process plugins that ship with Foundry may already be compiled into the
+            binary. Locally installed third-party in-process plugins still require generated imports
+            and a rebuild.
+          </p>
+
           <h2>Plugin runtime contract</h2>
           <p>
             Foundry now supports a first-class <code>runtime</code> block in

--- a/internal/admin/http/router.go
+++ b/internal/admin/http/router.go
@@ -67,14 +67,30 @@ func NewHooks(cfg *config.Config, base server.Hooks, opts ...service.Option) ser
 		return base
 	}
 
-	if pm, ok := base.(interface {
-		Metadata() map[string]plugins.Metadata
-	}); ok {
-		opts = append(opts, service.WithPluginMetadata(pm.Metadata))
+	if metadata := pluginMetadataProvider(base); metadata != nil {
+		opts = append(opts, service.WithPluginMetadata(metadata))
 	}
 	svc := service.New(cfg, opts...)
 	router := New(cfg, svc)
 	return WrapHooks(base, router)
+}
+
+func pluginMetadataProvider(h any) func() map[string]plugins.Metadata {
+	for h != nil {
+		if pm, ok := h.(interface {
+			Metadata() map[string]plugins.Metadata
+		}); ok {
+			return pm.Metadata
+		}
+		unwrap, ok := h.(interface {
+			UnwrapHooks() any
+		})
+		if !ok {
+			return nil
+		}
+		h = unwrap.UnwrapHooks()
+	}
+	return nil
 }
 
 // RegisterRegistrar appends an admin route group to the router.

--- a/internal/admin/http/router_test.go
+++ b/internal/admin/http/router_test.go
@@ -1130,6 +1130,9 @@ func TestHelpersAndHookWrapping(t *testing.T) {
 	if _, ok := NewHooks(&config.Config{Admin: config.AdminConfig{Enabled: true}}, base).(hookSet); !ok {
 		t.Fatal("expected enabled admin hooks to wrap base hooks")
 	}
+	if provider := pluginMetadataProvider(wrappedMetadataHooks{inner: metadataHooks{}}); provider == nil || provider()["alpha"].Title != "Alpha" {
+		t.Fatalf("expected plugin metadata provider through wrapped hooks")
+	}
 
 	r := New(&config.Config{Admin: config.AdminConfig{Enabled: true}}, service.New(testConfig(t)))
 	before := len(r.registrars)
@@ -1157,6 +1160,22 @@ func (stubHooks) OnRoutesAssigned(*content.SiteGraph) error { return nil }
 func (stubHooks) OnAssetsBuilding(*config.Config) error     { return nil }
 
 var _ server.Hooks = stubHooks{}
+
+type metadataHooks struct{}
+
+func (metadataHooks) RegisterRoutes(*http.ServeMux)             {}
+func (metadataHooks) OnServerStarted(string) error              { return nil }
+func (metadataHooks) OnRoutesAssigned(*content.SiteGraph) error { return nil }
+func (metadataHooks) OnAssetsBuilding(*config.Config) error     { return nil }
+func (metadataHooks) Metadata() map[string]plugins.Metadata {
+	return map[string]plugins.Metadata{"alpha": {Name: "alpha", Title: "Alpha"}}
+}
+
+type wrappedMetadataHooks struct {
+	inner any
+}
+
+func (w wrappedMetadataHooks) UnwrapHooks() any { return w.inner }
 
 func newTestRouter(t *testing.T, cfg *config.Config) *Router {
 	t.Helper()

--- a/internal/generated/plugins_gen.go
+++ b/internal/generated/plugins_gen.go
@@ -2,6 +2,7 @@
 package generated
 
 import (
+	_ "github.com/sphireinc/foundry/plugins/aiwriter"
 	_ "github.com/sphireinc/foundry/plugins/readingtime"
 	_ "github.com/sphireinc/foundry/plugins/relatedposts"
 	_ "github.com/sphireinc/foundry/plugins/toc"

--- a/internal/platformapi/platformapi.go
+++ b/internal/platformapi/platformapi.go
@@ -41,6 +41,10 @@ type hookSet struct {
 	api  *API
 }
 
+func (h hookSet) UnwrapHooks() any {
+	return h.base
+}
+
 // API serves Foundry's stable frontend-facing platform contract.
 //
 // Frontend themes and JS applications should prefer this surface, or the

--- a/internal/platformapi/platformapi_test.go
+++ b/internal/platformapi/platformapi_test.go
@@ -92,6 +92,30 @@ func TestPublicAPIEndpoints(t *testing.T) {
 	}
 }
 
+func TestHookSetExposesWrappedHooks(t *testing.T) {
+	base := passthroughHook{}
+	hooks := NewHooks(&config.Config{}, base)
+	source, ok := hooks.(interface {
+		UnwrapHooks() any
+	})
+	if !ok {
+		t.Fatal("expected platform hook set to expose wrapped hooks")
+	}
+	if source.UnwrapHooks() != base {
+		t.Fatalf("expected wrapped hook to be returned")
+	}
+}
+
+type passthroughHook struct{}
+
+func (h passthroughHook) RegisterRoutes(*http.ServeMux) {}
+
+func (h passthroughHook) OnServerStarted(string) error { return nil }
+
+func (h passthroughHook) OnRoutesAssigned(*content.SiteGraph) error { return nil }
+
+func (h passthroughHook) OnAssetsBuilding(*config.Config) error { return nil }
+
 func TestWriteStaticArtifacts(t *testing.T) {
 	cfg, graph := testGraph(t)
 	if err := WriteStaticArtifacts(cfg, graph); err != nil {

--- a/internal/plugins/analyzer.go
+++ b/internal/plugins/analyzer.go
@@ -149,9 +149,6 @@ func analyzePluginDirectory(root string) []SecurityFinding {
 			if strings.Contains(importPath, "/internal/admin/users") {
 				addFinding(&findings, seen, "admin.users.read", filepath.ToSlash(path), "import "+importPath, "touches admin users APIs", "direct")
 			}
-			if strings.Contains(importPath, "/internal/admin/auth") {
-				addFinding(&findings, seen, "admin.users.reset_passwords", filepath.ToSlash(path), "import "+importPath, "touches admin auth/session APIs", "heuristic")
-			}
 		}
 		for _, decl := range file.Decls {
 			fn, ok := decl.(*ast.FuncDecl)
@@ -460,9 +457,21 @@ func looksLikeSecretPath(value string) bool {
 	if value == "" {
 		return false
 	}
-	candidates := []string{".env", "id_rsa", "credentials", "secrets", "token", "session", "passwd", "private_key"}
+	candidates := []string{".env", "id_rsa", "credentials", "secrets", "session", "passwd", "private_key"}
 	for _, candidate := range candidates {
 		if strings.Contains(value, candidate) {
+			return true
+		}
+	}
+
+	return containsSensitivePathToken(value, "token")
+}
+
+func containsSensitivePathToken(value, token string) bool {
+	for _, part := range strings.FieldsFunc(value, func(r rune) bool {
+		return r == '/' || r == '\\' || r == '.' || r == '-' || r == ' '
+	}) {
+		if part == token {
 			return true
 		}
 	}

--- a/internal/plugins/metadata_validate_test.go
+++ b/internal/plugins/metadata_validate_test.go
@@ -171,6 +171,19 @@ func TestEnabledPluginStatusBranches(t *testing.T) {
 	}
 }
 
+func TestLooksLikeSecretPathDoesNotFlagTokenBudgetFields(t *testing.T) {
+	for _, value := range []string{"max_tokens", "max_output_tokens", "maxOutputTokens"} {
+		if looksLikeSecretPath(value) {
+			t.Fatalf("expected %q not to be classified as a secret path", value)
+		}
+	}
+	for _, value := range []string{".env", "config/secrets.yaml", "admin/session/store.yaml", "api-token"} {
+		if !looksLikeSecretPath(value) {
+			t.Fatalf("expected %q to be classified as a secret path", value)
+		}
+	}
+}
+
 func writePluginMetaFile(t *testing.T, root, name, body string) {
 	t.Helper()
 	dir := filepath.Join(root, name)

--- a/plugins/aiwriter/README.md
+++ b/plugins/aiwriter/README.md
@@ -1,0 +1,128 @@
+# AI Writer
+
+AI Writer adds an authenticated admin page that generates Foundry Markdown posts with an AI provider. It supports OpenAI, Anthropic Claude, and Google Gemini through server-side HTTP calls so API keys are never exposed to browser JavaScript.
+
+Generated output is written as a new Markdown file under the configured Foundry posts directory. Existing files are not overwritten. The frontmatter slug controls the post URL, while Foundry generates the filename so user input never controls the filesystem path.
+
+## What It Does
+
+- Adds an **AI Writer** page to the Admin UI under the content navigation group.
+- Lets an admin enter a post prompt plus optional title, slug, status, language, author, summary, tags, and categories.
+- Wraps the user prompt in Foundry-specific instructions so the provider returns one complete Markdown post with YAML frontmatter.
+- Calls OpenAI, Anthropic Claude, or Gemini from the server.
+- Writes the generated Markdown as a draft-style post in `content/<posts_dir>/` using a server-generated filename.
+- Marks generated posts with AI provenance frontmatter so they can be counted and audited later.
+- Shows provider-reported token usage for the last request and for the current Foundry process.
+
+## Enable The Plugin
+
+Add `aiwriter` to the enabled plugin list in your Foundry site config:
+
+```yaml
+plugins:
+  enabled:
+    - aiwriter
+```
+
+If you are running from source, sync plugin imports and rebuild after enabling:
+
+```sh
+go run ./cmd/plugin-sync
+go build ./cmd/foundry
+```
+
+## Configuration
+
+Configure the plugin under `params.ai_writer`. API keys should normally come from environment variables, not from the config file.
+
+```yaml
+params:
+  ai_writer:
+    provider: openai
+    api_key_env: OPENAI_API_KEY
+    model: gpt-4o-mini
+    endpoint_version: v1
+    temperature: 0.7
+    max_tokens: 2400
+    timeout_seconds: 60
+    default_status: draft
+    default_author: Foundry Team
+    default_lang: en
+    system_prompt: >
+      Match our site voice: direct, practical, and concise.
+```
+
+### Provider Examples
+
+OpenAI:
+
+```yaml
+params:
+  ai_writer:
+    provider: openai
+    api_key_env: OPENAI_API_KEY
+    model: gpt-4o-mini
+```
+
+Anthropic Claude:
+
+```yaml
+params:
+  ai_writer:
+    provider: anthropic
+    api_key_env: ANTHROPIC_API_KEY
+    model: claude-3-5-haiku-latest
+```
+
+Google Gemini:
+
+```yaml
+params:
+  ai_writer:
+    provider: gemini
+    api_key_env: GEMINI_API_KEY
+    model: gemini-1.5-flash
+```
+
+## Options
+
+- `provider`: `openai`, `anthropic`, `claude`, `gemini`, or `google`.
+- `api_key_env`: Environment variable that contains the provider API key.
+- `api_key`: Inline API key. Supported, but not recommended for production.
+- `model`: Provider model name.
+- `endpoint`: Optional provider endpoint override, useful for tests or gateways.
+- `endpoint_version`: API endpoint version for the provider default endpoint. Defaults are `v1` for OpenAI and Anthropic, and `v1beta` for Gemini. Custom endpoint overrides can include `{version}` to reuse this value.
+- `temperature`: Provider sampling temperature.
+- `max_tokens`: Maximum output token budget.
+- `timeout_seconds`: HTTP timeout for provider requests.
+- `default_status`: Default frontmatter status when the admin form does not override it.
+- `default_author`: Default frontmatter author.
+- `default_lang`: Default frontmatter language.
+- `system_prompt`: Additional site-specific writing instructions appended to the built-in Foundry prompt.
+
+## Admin Usage
+
+Open the Admin UI and select **AI Writer**. Enter the prompt and any optional metadata. The generated post is written immediately when you press **Generate and write post**, and the page shows the saved path plus the generated Markdown preview.
+
+The route requires an authenticated admin session with `documents.create`.
+
+## AI Provenance
+
+Generated posts include frontmatter like this:
+
+```yaml
+ai_generated: true
+ai_provider: openai
+ai_model: gpt-4o-mini
+ai_generated_at: "2026-04-16T19:00:00Z"
+```
+
+The Admin UI counts posts with `ai_generated: true` and displays provider-reported token usage when the provider returns it. Runtime token totals are kept in memory for the current Foundry process; the frontmatter marker is durable.
+
+## Security Notes
+
+- API keys stay on the server. The Admin UI only receives a redacted configuration status.
+- The plugin only writes inside Foundry's configured content posts directory with server-generated filenames.
+- Existing Markdown files are not overwritten.
+- Provider calls are outbound HTTPS requests to the configured AI provider.
+- The plugin requires admin approval because it combines outbound network access with content writes.

--- a/plugins/aiwriter/assets/admin.css
+++ b/plugins/aiwriter/assets/admin.css
@@ -1,0 +1,168 @@
+.aiwriter-shell {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.aiwriter-hero {
+  align-items: stretch;
+  background:
+    radial-gradient(circle at top left, rgba(38, 105, 179, 0.16), transparent 34rem),
+    linear-gradient(135deg, #f8faf7, #eef4ef);
+  border: 1px solid rgba(20, 37, 24, 0.12);
+  border-radius: 24px;
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: minmax(0, 1fr) minmax(14rem, 20rem);
+  padding: 1.5rem;
+}
+
+.aiwriter-hero h2,
+.aiwriter-result h3 {
+  margin: 0.2rem 0;
+}
+
+.aiwriter-eyebrow,
+.aiwriter-label {
+  color: #42614b;
+  font-size: 0.76rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  margin: 0;
+  text-transform: uppercase;
+}
+
+.aiwriter-muted {
+  color: #5b665d;
+  margin: 0.35rem 0 0;
+}
+
+.aiwriter-provider-card {
+  background: rgba(255, 255, 255, 0.74);
+  border: 1px solid rgba(20, 37, 24, 0.12);
+  border-radius: 18px;
+  display: grid;
+  gap: 0.4rem;
+  padding: 1rem;
+}
+
+.aiwriter-stats {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.aiwriter-stats article {
+  background: #fff;
+  border: 1px solid rgba(20, 37, 24, 0.12);
+  border-radius: 18px;
+  display: grid;
+  gap: 0.35rem;
+  padding: 1rem;
+}
+
+.aiwriter-stats strong {
+  font-size: 1.05rem;
+}
+
+.aiwriter-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.aiwriter-grid label {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.aiwriter-grid label span {
+  font-weight: 650;
+}
+
+.aiwriter-grid input,
+.aiwriter-grid select,
+.aiwriter-grid textarea {
+  border: 1px solid rgba(20, 37, 24, 0.18);
+  border-radius: 14px;
+  font: inherit;
+  padding: 0.75rem 0.85rem;
+}
+
+.aiwriter-grid textarea {
+  resize: vertical;
+}
+
+.aiwriter-full {
+  grid-column: 1 / -1;
+}
+
+.aiwriter-actions {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.aiwriter-actions button {
+  border: 1px solid rgba(20, 37, 24, 0.18);
+  border-radius: 999px;
+  cursor: pointer;
+  font-weight: 700;
+  padding: 0.7rem 1rem;
+}
+
+.aiwriter-actions button:disabled {
+  cursor: wait;
+  opacity: 0.7;
+}
+
+.aiwriter-primary {
+  background: #193d2c;
+  color: #fff;
+}
+
+.aiwriter-message {
+  border-radius: 16px;
+  padding: 0.8rem 1rem;
+}
+
+.aiwriter-message[data-type="success"] {
+  background: #e7f6eb;
+  color: #174323;
+}
+
+.aiwriter-message[data-type="warning"] {
+  background: #fff4d6;
+  color: #674b00;
+}
+
+.aiwriter-message[data-type="error"] {
+  background: #ffe3df;
+  color: #7a1d12;
+}
+
+.aiwriter-result {
+  border: 1px solid rgba(20, 37, 24, 0.12);
+  border-radius: 22px;
+  overflow: hidden;
+}
+
+.aiwriter-result-header {
+  background: #f8faf7;
+  border-bottom: 1px solid rgba(20, 37, 24, 0.12);
+  padding: 1rem;
+}
+
+.aiwriter-result pre {
+  margin: 0;
+  max-height: 42rem;
+  overflow: auto;
+  padding: 1rem;
+  white-space: pre-wrap;
+}
+
+@media (max-width: 760px) {
+  .aiwriter-hero,
+  .aiwriter-grid,
+  .aiwriter-stats {
+    grid-template-columns: 1fr;
+  }
+}

--- a/plugins/aiwriter/assets/admin.js
+++ b/plugins/aiwriter/assets/admin.js
@@ -1,0 +1,239 @@
+const splitList = (value) =>
+  String(value || '')
+    .split(',')
+    .map((item) => item.trim())
+    .filter(Boolean);
+
+const renderSettings = (settings) => {
+  if (!settings) return 'Settings unavailable';
+  const configured = settings.configured ? 'configured' : 'missing API key';
+  return `${settings.provider || 'openai'} / ${settings.model || 'default'} (${configured}, ${settings.key_source || 'unknown'})`;
+};
+
+const formatNumber = (value) => new Intl.NumberFormat().format(Number(value || 0));
+
+const formatUsageLine = (usage = {}) =>
+  `${formatNumber(usage.prompt_tokens || 0)} prompt / ${formatNumber(usage.completion_tokens || 0)} completion / ${formatNumber(usage.total_tokens || 0)} total`;
+
+export const mountAdminExtensionPage = async ({
+  mount,
+  page = {},
+  client,
+} = {}) => {
+  if (page.key !== 'ai-writer') return;
+
+  client = client || window.FoundryAdmin?.client;
+  if (!mount || !client?.raw) return;
+
+  mount.innerHTML = `
+    <section class="aiwriter-shell">
+      <div class="aiwriter-hero">
+        <div>
+          <p class="aiwriter-eyebrow">AI Writer</p>
+          <h2>Generate a Foundry Markdown post</h2>
+          <p class="aiwriter-muted">Prompt an approved provider from the admin UI. API keys stay server-side and generated posts are written as draft Markdown files under the configured posts directory.</p>
+        </div>
+        <div class="aiwriter-provider-card">
+          <span class="aiwriter-label">Provider</span>
+          <strong id="aiwriter-provider-status">Loading settings...</strong>
+        </div>
+      </div>
+
+      <div class="aiwriter-stats">
+        <article>
+          <span class="aiwriter-label">AI-written posts</span>
+          <strong id="aiwriter-ai-post-count">-</strong>
+          <p class="aiwriter-muted">Posts marked with <code>ai_generated: true</code>.</p>
+        </article>
+        <article>
+          <span class="aiwriter-label">This process</span>
+          <strong id="aiwriter-run-generations">-</strong>
+          <p class="aiwriter-muted">Generated since the current Foundry process started.</p>
+        </article>
+        <article>
+          <span class="aiwriter-label">Token usage</span>
+          <strong id="aiwriter-run-tokens">-</strong>
+          <p class="aiwriter-muted">Provider-reported tokens for this process.</p>
+        </article>
+        <article>
+          <span class="aiwriter-label">Last request</span>
+          <strong id="aiwriter-last-tokens">-</strong>
+          <p class="aiwriter-muted">Prompt / completion / total tokens.</p>
+        </article>
+      </div>
+
+      <form id="aiwriter-form" class="aiwriter-grid">
+        <label class="aiwriter-full">
+          <span>What should the post be about?</span>
+          <textarea name="prompt" rows="8" required placeholder="Example: Write a practical guide for small teams migrating a documentation site into Foundry. Include tradeoffs, workflow tips, and a launch checklist."></textarea>
+        </label>
+
+        <label>
+          <span>Title override</span>
+          <input name="title" type="text" placeholder="Optional">
+        </label>
+
+        <label>
+          <span>Slug override</span>
+          <input name="slug" type="text" placeholder="optional-post-slug">
+        </label>
+
+        <label>
+          <span>Status</span>
+          <select name="status">
+            <option value="draft">Draft</option>
+            <option value="review">Review</option>
+            <option value="published">Published</option>
+          </select>
+        </label>
+
+        <label>
+          <span>Language</span>
+          <input name="lang" type="text" placeholder="en">
+        </label>
+
+        <label>
+          <span>Author</span>
+          <input name="author" type="text" placeholder="Optional">
+        </label>
+
+        <label>
+          <span>Summary</span>
+          <input name="summary" type="text" placeholder="Optional frontmatter summary">
+        </label>
+
+        <label>
+          <span>Tags</span>
+          <input name="tags" type="text" placeholder="comma, separated, tags">
+        </label>
+
+        <label>
+          <span>Categories</span>
+          <input name="categories" type="text" placeholder="comma, separated, categories">
+        </label>
+
+        <div class="aiwriter-actions aiwriter-full">
+          <button type="submit" class="aiwriter-primary">Generate and write post</button>
+          <button type="button" id="aiwriter-clear">Clear</button>
+        </div>
+      </form>
+
+      <div id="aiwriter-message" class="aiwriter-message" hidden></div>
+
+      <section id="aiwriter-result" class="aiwriter-result" hidden>
+        <div class="aiwriter-result-header">
+          <div>
+            <p class="aiwriter-eyebrow">Generated Post</p>
+            <h3 id="aiwriter-result-title"></h3>
+            <p id="aiwriter-result-meta" class="aiwriter-muted"></p>
+          </div>
+        </div>
+        <pre id="aiwriter-markdown"></pre>
+      </section>
+    </section>
+  `;
+
+  const status = mount.querySelector('#aiwriter-provider-status');
+  const aiPostCount = mount.querySelector('#aiwriter-ai-post-count');
+  const runGenerations = mount.querySelector('#aiwriter-run-generations');
+  const runTokens = mount.querySelector('#aiwriter-run-tokens');
+  const lastTokens = mount.querySelector('#aiwriter-last-tokens');
+  const form = mount.querySelector('#aiwriter-form');
+  const message = mount.querySelector('#aiwriter-message');
+  const result = mount.querySelector('#aiwriter-result');
+  const resultTitle = mount.querySelector('#aiwriter-result-title');
+  const resultMeta = mount.querySelector('#aiwriter-result-meta');
+  const markdown = mount.querySelector('#aiwriter-markdown');
+
+  const showMessage = (text, type = 'info') => {
+    message.textContent = text;
+    message.dataset.type = type;
+    message.hidden = false;
+  };
+
+  const clearMessage = () => {
+    message.textContent = '';
+    message.hidden = true;
+  };
+
+  const applySettings = (settings) => {
+    status.textContent = renderSettings(settings);
+    const usage = settings.usage || {};
+    aiPostCount.textContent = formatNumber(usage.ai_written_posts || 0);
+    runGenerations.textContent = formatNumber(usage.generations_this_run || 0);
+    runTokens.textContent = formatUsageLine({
+      prompt_tokens: usage.prompt_tokens_this_run,
+      completion_tokens: usage.completion_tokens_this_run,
+      total_tokens: usage.total_tokens_this_run,
+    });
+    lastTokens.textContent = formatUsageLine(usage.last_request || {});
+  };
+
+  const refreshSettings = async () => {
+    const settings = await client.raw.get('/plugin-api/aiwriter/settings');
+    applySettings(settings);
+    return settings;
+  };
+
+  try {
+    const settings = await refreshSettings();
+    if (!settings.configured) {
+      showMessage('Configure an API key environment variable or params.ai_writer.api_key before generating posts.', 'warning');
+    }
+  } catch (error) {
+    status.textContent = 'Settings unavailable';
+    showMessage(error?.message || String(error), 'error');
+  }
+
+  mount.querySelector('#aiwriter-clear')?.addEventListener('click', () => {
+    form.reset();
+    result.hidden = true;
+    clearMessage();
+  });
+
+  form.addEventListener('submit', async (submitEvent) => {
+    submitEvent.preventDefault();
+    clearMessage();
+    result.hidden = true;
+
+    const submit = form.querySelector('button[type="submit"]');
+    const formData = new FormData(form);
+    const payload = {
+      prompt: formData.get('prompt'),
+      title: formData.get('title'),
+      slug: formData.get('slug'),
+      status: formData.get('status'),
+      lang: formData.get('lang'),
+      author: formData.get('author'),
+      summary: formData.get('summary'),
+      tags: splitList(formData.get('tags')),
+      categories: splitList(formData.get('categories')),
+    };
+
+    submit.disabled = true;
+    submit.textContent = 'Generating...';
+    try {
+      const generated = await client.raw.post('/plugin-api/aiwriter/generate', payload);
+      resultTitle.textContent = generated.title || 'Generated post';
+      resultMeta.textContent = `${generated.path || 'unknown path'} · ${generated.provider || 'provider'} / ${generated.model || 'model'} · ${generated.status || 'draft'} · ${formatUsageLine(generated.usage || {})}`;
+      markdown.textContent = generated.markdown || '';
+      result.hidden = false;
+      await refreshSettings();
+      showMessage(`Wrote ${generated.path || 'the generated post'}`, 'success');
+    } catch (error) {
+      showMessage(error?.message || String(error), 'error');
+    } finally {
+      submit.disabled = false;
+      submit.textContent = 'Generate and write post';
+    }
+  });
+};
+
+document.addEventListener('foundry:admin-extension-page', (event) => {
+  const detail = event.detail || {};
+  void mountAdminExtensionPage({
+    mount: document.getElementById(detail.mountId || 'admin-extension-mount'),
+    page: detail.page || {},
+    client: window.FoundryAdmin?.client,
+  });
+});

--- a/plugins/aiwriter/plugin.go
+++ b/plugins/aiwriter/plugin.go
@@ -1,0 +1,1040 @@
+package aiwriter
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+	"unicode"
+
+	adminauth "github.com/sphireinc/foundry/internal/admin/auth"
+	"github.com/sphireinc/foundry/internal/config"
+	"github.com/sphireinc/foundry/internal/plugins"
+	"github.com/sphireinc/foundry/internal/safepath"
+)
+
+const (
+	pluginName            = "aiwriter"
+	defaultTimeoutSeconds = 60
+	defaultTemperature    = 0.7
+	defaultMaxTokens      = 2400
+	defaultOpenAIModel    = "gpt-4o-mini"
+	defaultAnthropicModel = "claude-3-5-haiku-latest"
+	defaultGeminiModel    = "gemini-1.5-flash"
+
+	defaultOpenAIEndpoint = "https://api.openai.com/{version}/responses"
+	defaultOpenAIVersion  = "v1"
+
+	defaultAnthropicURL     = "https://api.anthropic.com/{version}/messages"
+	defaultAnthropicVersion = "v1"
+
+	defaultGeminiEndpoint = "https://generativelanguage.googleapis.com/{version}/models/%s:generateContent"
+	defaultGeminiVersion  = "v1beta"
+
+	defaultGeneratedStatus  = "draft"
+	adminGenerateCapability = "documents.create"
+)
+
+var frontmatterValuePattern = regexp.MustCompile(`(?m)^([A-Za-z0-9_-]+):\s*"?([^"\n]+)"?\s*$`)
+
+type Plugin struct {
+	mu       sync.RWMutex
+	cfg      *config.Config
+	settings Settings
+	client   *http.Client
+	usage    UsageStats
+}
+
+type Settings struct {
+	Provider        string  `json:"provider"`
+	APIKey          string  `json:"-"`
+	APIKeyEnv       string  `json:"api_key_env"`
+	Model           string  `json:"model"`
+	Endpoint        string  `json:"endpoint,omitempty"`
+	EndpointVersion string  `json:"endpoint_version,omitempty"`
+	SystemPrompt    string  `json:"system_prompt,omitempty"`
+	DefaultStatus   string  `json:"default_status"`
+	DefaultAuthor   string  `json:"default_author,omitempty"`
+	DefaultLang     string  `json:"default_lang,omitempty"`
+	Temperature     float64 `json:"temperature"`
+	MaxTokens       int     `json:"max_tokens"`
+	TimeoutSeconds  int     `json:"timeout_seconds"`
+}
+
+type GenerateRequest struct {
+	Prompt     string   `json:"prompt"`
+	Title      string   `json:"title,omitempty"`
+	Slug       string   `json:"slug,omitempty"`
+	Status     string   `json:"status,omitempty"`
+	Author     string   `json:"author,omitempty"`
+	Lang       string   `json:"lang,omitempty"`
+	Summary    string   `json:"summary,omitempty"`
+	Tags       []string `json:"tags,omitempty"`
+	Categories []string `json:"categories,omitempty"`
+}
+
+type GenerateResponse struct {
+	Path     string     `json:"path"`
+	Title    string     `json:"title"`
+	Slug     string     `json:"slug"`
+	Status   string     `json:"status"`
+	Provider string     `json:"provider"`
+	Model    string     `json:"model"`
+	Markdown string     `json:"markdown"`
+	Usage    TokenUsage `json:"usage"`
+}
+
+type TokenUsage struct {
+	PromptTokens     int `json:"prompt_tokens"`
+	CompletionTokens int `json:"completion_tokens"`
+	TotalTokens      int `json:"total_tokens"`
+}
+
+type UsageStats struct {
+	AIWrittenPosts          int        `json:"ai_written_posts"`
+	GenerationsThisRun      int        `json:"generations_this_run"`
+	PromptTokensThisRun     int        `json:"prompt_tokens_this_run"`
+	CompletionTokensThisRun int        `json:"completion_tokens_this_run"`
+	TotalTokensThisRun      int        `json:"total_tokens_this_run"`
+	LastRequest             TokenUsage `json:"last_request"`
+}
+
+type settingsResponse struct {
+	Settings
+	Configured bool       `json:"configured"`
+	KeySource  string     `json:"key_source"`
+	Usage      UsageStats `json:"usage"`
+}
+
+func New() *Plugin {
+	return &Plugin{}
+}
+
+func (p *Plugin) Name() string {
+	return pluginName
+}
+
+func (p *Plugin) OnConfigLoaded(cfg *config.Config) error {
+	settings := settingsFromConfig(cfg)
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.cfg = cfg
+	p.settings = settings
+	p.client = &http.Client{Timeout: time.Duration(settings.TimeoutSeconds) * time.Second}
+	return nil
+}
+
+func (p *Plugin) RegisterRoutes(mux *http.ServeMux) {
+	cfg, _, _ := p.snapshot()
+	if mux == nil || cfg == nil {
+		return
+	}
+
+	auth := adminauth.New(cfg)
+	base := strings.TrimRight(cfg.AdminPath(), "/") + "/plugin-api/aiwriter"
+	mux.Handle(base+"/settings", auth.WrapCapability(http.HandlerFunc(p.handleSettings), adminGenerateCapability))
+	mux.Handle(base+"/generate", auth.WrapCapability(http.HandlerFunc(p.handleGenerate), adminGenerateCapability))
+}
+
+func (p *Plugin) handleSettings(w http.ResponseWriter, req *http.Request) {
+	if req.Method != http.MethodGet && req.Method != http.MethodHead {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	cfg, settings, _ := p.snapshot()
+	_, source := settings.resolveAPIKey()
+	usage := p.usageSnapshot()
+	usage.AIWrittenPosts = countAIWrittenPosts(cfg)
+	writeJSON(w, http.StatusOK, settingsResponse{
+		Settings:   settings.redacted(),
+		Configured: source != "missing",
+		KeySource:  source,
+		Usage:      usage,
+	})
+}
+
+func (p *Plugin) handleGenerate(w http.ResponseWriter, req *http.Request) {
+	if req.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	defer req.Body.Close()
+
+	var body GenerateRequest
+	dec := json.NewDecoder(io.LimitReader(req.Body, 128*1024))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&body); err != nil {
+		writeJSONError(w, http.StatusBadRequest, err)
+		return
+	}
+
+	resp, err := p.GenerateAndWrite(req.Context(), body)
+	if err != nil {
+		writeJSONError(w, http.StatusBadRequest, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+func (p *Plugin) GenerateAndWrite(ctx context.Context, body GenerateRequest) (*GenerateResponse, error) {
+	cfg, settings, client := p.snapshot()
+	if cfg == nil {
+		return nil, fmt.Errorf("ai writer plugin is not configured")
+	}
+	if strings.TrimSpace(body.Prompt) == "" {
+		return nil, fmt.Errorf("prompt is required")
+	}
+	if client == nil {
+		client = http.DefaultClient
+	}
+
+	prompt := buildPrompt(settings, body)
+	markdown, usage, err := requestCompletion(ctx, client, settings, prompt)
+	if err != nil {
+		return nil, err
+	}
+	p.recordUsage(usage)
+	markdown = normalizeMarkdown(markdown)
+	markdown, title, slug, status := completeMarkdownDocument(markdown, settings, body)
+
+	path, err := writePost(cfg, markdown)
+	if err != nil {
+		return nil, err
+	}
+
+	return &GenerateResponse{
+		Path:     filepath.ToSlash(path),
+		Title:    title,
+		Slug:     slug,
+		Status:   status,
+		Provider: settings.Provider,
+		Model:    settings.Model,
+		Markdown: markdown,
+		Usage:    usage,
+	}, nil
+}
+
+func (p *Plugin) snapshot() (*config.Config, Settings, *http.Client) {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.cfg, p.settings, p.client
+}
+
+func (p *Plugin) usageSnapshot() UsageStats {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.usage
+}
+
+func (p *Plugin) recordUsage(usage TokenUsage) {
+	if usage.PromptTokens == 0 && usage.CompletionTokens == 0 && usage.TotalTokens == 0 {
+		return
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.usage.GenerationsThisRun++
+	p.usage.PromptTokensThisRun += usage.PromptTokens
+	p.usage.CompletionTokensThisRun += usage.CompletionTokens
+	p.usage.TotalTokensThisRun += usage.TotalTokens
+	p.usage.LastRequest = usage
+}
+
+func settingsFromConfig(cfg *config.Config) Settings {
+	defaultLang := ""
+	if cfg != nil {
+		defaultLang = strings.TrimSpace(cfg.DefaultLang)
+	}
+	settings := Settings{
+		Provider:        "openai",
+		APIKeyEnv:       "OPENAI_API_KEY",
+		Model:           defaultOpenAIModel,
+		EndpointVersion: defaultVersion("openai"),
+		Endpoint:        defaultEndpoint("openai", defaultOpenAIModel, ""),
+		DefaultStatus:   defaultGeneratedStatus,
+		DefaultLang:     defaultLang,
+		Temperature:     defaultTemperature,
+		MaxTokens:       defaultMaxTokens,
+		TimeoutSeconds:  defaultTimeoutSeconds,
+	}
+	if cfg == nil || cfg.Params == nil {
+		return settings
+	}
+
+	raw, _ := cfg.Params["ai_writer"]
+	values, ok := raw.(map[string]any)
+	if !ok {
+		if typed, ok := raw.(map[any]any); ok {
+			values = make(map[string]any, len(typed))
+			for k, v := range typed {
+				values[fmt.Sprint(k)] = v
+			}
+		}
+	}
+	if len(values) == 0 {
+		return settings
+	}
+
+	settings.Provider = lowerString(settingString(values, "provider", settings.Provider))
+	settings.APIKey = settingString(values, "api_key", "")
+	settings.APIKeyEnv = settingString(values, "api_key_env", defaultAPIKeyEnv(settings.Provider))
+	if settings.APIKey == "" && settings.APIKeyEnv != "" && !isValidEnvVarName(settings.APIKeyEnv) {
+		settings.APIKey = settings.APIKeyEnv
+		settings.APIKeyEnv = defaultAPIKeyEnv(settings.Provider)
+	}
+	settings.Model = settingString(values, "model", defaultModel(settings.Provider))
+	settings.EndpointVersion = settingString(values, "endpoint_version", defaultVersion(settings.Provider))
+	settings.Endpoint = resolveEndpoint(
+		settings.Provider,
+		settings.Model,
+		settingString(values, "endpoint", ""),
+		settings.EndpointVersion,
+	)
+	settings.SystemPrompt = settingString(values, "system_prompt", "")
+	settings.DefaultStatus = lowerString(settingString(values, "default_status", settings.DefaultStatus))
+	settings.DefaultAuthor = settingString(values, "default_author", "")
+	settings.DefaultLang = settingString(values, "default_lang", settings.DefaultLang)
+	settings.Temperature = settingFloat(values, "temperature", settings.Temperature)
+	settings.MaxTokens = settingInt(values, "max_tokens", settings.MaxTokens)
+	settings.TimeoutSeconds = settingInt(values, "timeout_seconds", settings.TimeoutSeconds)
+
+	if settings.TimeoutSeconds <= 0 {
+		settings.TimeoutSeconds = defaultTimeoutSeconds
+	}
+	if settings.MaxTokens <= 0 {
+		settings.MaxTokens = defaultMaxTokens
+	}
+	if settings.Temperature < 0 {
+		settings.Temperature = 0
+	}
+	if settings.APIKeyEnv == "" {
+		settings.APIKeyEnv = defaultAPIKeyEnv(settings.Provider)
+	}
+	if settings.Model == "" {
+		settings.Model = defaultModel(settings.Provider)
+	}
+	if settings.EndpointVersion == "" {
+		settings.EndpointVersion = defaultVersion(settings.Provider)
+	}
+	if settings.Endpoint == "" {
+		settings.Endpoint = defaultEndpoint(settings.Provider, settings.Model, settings.EndpointVersion)
+	}
+	if settings.DefaultStatus == "" {
+		settings.DefaultStatus = defaultGeneratedStatus
+	}
+	return settings
+}
+
+func (s Settings) redacted() Settings {
+	s.APIKey = ""
+	return s
+}
+
+func (s Settings) resolveAPIKey() (string, string) {
+	if strings.TrimSpace(s.APIKey) != "" {
+		return strings.TrimSpace(s.APIKey), "config"
+	}
+	envName := strings.TrimSpace(s.APIKeyEnv)
+	if envName == "" {
+		envName = defaultAPIKeyEnv(s.Provider)
+	}
+	if envName != "" {
+		if value := strings.TrimSpace(os.Getenv(envName)); value != "" {
+			return value, "env:" + envName
+		}
+	}
+	return "", "missing"
+}
+
+func requestCompletion(ctx context.Context, client *http.Client, settings Settings, prompt string) (string, TokenUsage, error) {
+	switch strings.ToLower(strings.TrimSpace(settings.Provider)) {
+	case "openai":
+		return requestOpenAI(ctx, client, settings, prompt)
+	case "anthropic", "claude":
+		return requestAnthropic(ctx, client, settings, prompt)
+	case "gemini", "google":
+		return requestGemini(ctx, client, settings, prompt)
+	default:
+		return "", TokenUsage{}, fmt.Errorf("unsupported AI provider %q", settings.Provider)
+	}
+}
+
+func requestOpenAI(ctx context.Context, client *http.Client, settings Settings, prompt string) (string, TokenUsage, error) {
+	key, source := settings.resolveAPIKey()
+	if key == "" {
+		return "", TokenUsage{}, fmt.Errorf("OpenAI API key is not configured (%s)", source)
+	}
+	payload := map[string]any{
+		"model":             settings.Model,
+		"input":             prompt,
+		"temperature":       settings.Temperature,
+		"max_output_tokens": settings.MaxTokens,
+	}
+	var out struct {
+		OutputText string `json:"output_text"`
+		Output     []struct {
+			Content []struct {
+				Text string `json:"text"`
+				Type string `json:"type"`
+			} `json:"content"`
+		} `json:"output"`
+		Usage struct {
+			InputTokens  int `json:"input_tokens"`
+			OutputTokens int `json:"output_tokens"`
+			TotalTokens  int `json:"total_tokens"`
+		} `json:"usage"`
+	}
+	if err := doJSON(ctx, client, http.MethodPost, settings.Endpoint, key, "bearer", payload, &out); err != nil {
+		return "", TokenUsage{}, err
+	}
+	usage := normalizeUsage(out.Usage.InputTokens, out.Usage.OutputTokens, out.Usage.TotalTokens)
+	if strings.TrimSpace(out.OutputText) != "" {
+		return out.OutputText, usage, nil
+	}
+	var b strings.Builder
+	for _, item := range out.Output {
+		for _, content := range item.Content {
+			if strings.TrimSpace(content.Text) != "" {
+				b.WriteString(content.Text)
+			}
+		}
+	}
+	text, err := requireText(b.String(), "OpenAI")
+	return text, usage, err
+}
+
+func requestAnthropic(ctx context.Context, client *http.Client, settings Settings, prompt string) (string, TokenUsage, error) {
+	key, source := settings.resolveAPIKey()
+	if key == "" {
+		return "", TokenUsage{}, fmt.Errorf("Anthropic API key is not configured (%s)", source)
+	}
+	payload := map[string]any{
+		"model":       settings.Model,
+		"max_tokens":  settings.MaxTokens,
+		"temperature": settings.Temperature,
+		"messages": []map[string]any{
+			{"role": "user", "content": prompt},
+		},
+	}
+	var out struct {
+		Content []struct {
+			Type string `json:"type"`
+			Text string `json:"text"`
+		} `json:"content"`
+		Usage struct {
+			InputTokens  int `json:"input_tokens"`
+			OutputTokens int `json:"output_tokens"`
+		} `json:"usage"`
+	}
+	if err := doJSON(ctx, client, http.MethodPost, settings.Endpoint, key, "anthropic", payload, &out); err != nil {
+		return "", TokenUsage{}, err
+	}
+	usage := normalizeUsage(out.Usage.InputTokens, out.Usage.OutputTokens, 0)
+	var b strings.Builder
+	for _, content := range out.Content {
+		if strings.TrimSpace(content.Text) != "" {
+			b.WriteString(content.Text)
+		}
+	}
+	text, err := requireText(b.String(), "Anthropic")
+	return text, usage, err
+}
+
+func requestGemini(ctx context.Context, client *http.Client, settings Settings, prompt string) (string, TokenUsage, error) {
+	key, source := settings.resolveAPIKey()
+	if key == "" {
+		return "", TokenUsage{}, fmt.Errorf("Gemini API key is not configured (%s)", source)
+	}
+	endpoint, err := endpointWithQueryKey(settings.Endpoint, key)
+	if err != nil {
+		return "", TokenUsage{}, err
+	}
+	payload := map[string]any{
+		"contents": []map[string]any{
+			{"role": "user", "parts": []map[string]any{{"text": prompt}}},
+		},
+		"generationConfig": map[string]any{
+			"temperature":     settings.Temperature,
+			"maxOutputTokens": settings.MaxTokens,
+		},
+	}
+	var out struct {
+		Candidates []struct {
+			Content struct {
+				Parts []struct {
+					Text string `json:"text"`
+				} `json:"parts"`
+			} `json:"content"`
+		} `json:"candidates"`
+		UsageMetadata struct {
+			PromptTokenCount     int `json:"promptTokenCount"`
+			CandidatesTokenCount int `json:"candidatesTokenCount"`
+			TotalTokenCount      int `json:"totalTokenCount"`
+		} `json:"usageMetadata"`
+	}
+	if err := doJSON(ctx, client, http.MethodPost, endpoint, "", "", payload, &out); err != nil {
+		return "", TokenUsage{}, err
+	}
+	usage := normalizeUsage(out.UsageMetadata.PromptTokenCount, out.UsageMetadata.CandidatesTokenCount, out.UsageMetadata.TotalTokenCount)
+	var b strings.Builder
+	for _, candidate := range out.Candidates {
+		for _, part := range candidate.Content.Parts {
+			if strings.TrimSpace(part.Text) != "" {
+				b.WriteString(part.Text)
+			}
+		}
+	}
+	text, err := requireText(b.String(), "Gemini")
+	return text, usage, err
+}
+
+func doJSON(ctx context.Context, client *http.Client, method, endpoint, key, authStyle string, payload any, out any) error {
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, method, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	switch authStyle {
+	case "bearer":
+		req.Header.Set("Authorization", "Bearer "+key)
+	case "anthropic":
+		req.Header.Set("x-api-key", key)
+		req.Header.Set("anthropic-version", "2023-06-01")
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	limited := io.LimitReader(resp.Body, 4*1024*1024)
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		message, _ := io.ReadAll(limited)
+		return fmt.Errorf("AI provider returned %s: %s", resp.Status, strings.TrimSpace(string(message)))
+	}
+	if out == nil {
+		return nil
+	}
+	if err := json.NewDecoder(limited).Decode(out); err != nil {
+		return err
+	}
+	return nil
+}
+
+func normalizeUsage(prompt, completion, total int) TokenUsage {
+	if total == 0 && (prompt != 0 || completion != 0) {
+		total = prompt + completion
+	}
+	return TokenUsage{
+		PromptTokens:     prompt,
+		CompletionTokens: completion,
+		TotalTokens:      total,
+	}
+}
+
+func buildPrompt(settings Settings, req GenerateRequest) string {
+	var b strings.Builder
+	b.WriteString("You are writing content for Foundry, a Markdown-driven CMS written in Go.\n")
+	b.WriteString("Return exactly one complete Markdown post. Do not wrap the answer in code fences. Do not include commentary before or after the document.\n")
+	b.WriteString("The document must start with YAML frontmatter between --- markers, followed by a polished Markdown body.\n")
+	b.WriteString("Use frontmatter keys: title, slug, date, status, summary, tags, categories, author, lang, layout.\n")
+	b.WriteString("Foundry will add AI provenance frontmatter automatically; do not invent provider usage metadata.\n")
+	b.WriteString("Use layout: post. Use valid YAML arrays for tags and categories. Use status draft unless the request says otherwise.\n")
+	b.WriteString("Write helpful, original prose with clear headings, concise paragraphs, and practical examples when useful.\n")
+	if strings.TrimSpace(settings.SystemPrompt) != "" {
+		b.WriteString("\nAdditional site instructions:\n")
+		b.WriteString(strings.TrimSpace(settings.SystemPrompt))
+		b.WriteString("\n")
+	}
+	b.WriteString("\nRequested post options:\n")
+	appendPromptField(&b, "Title", req.Title)
+	appendPromptField(&b, "Slug", req.Slug)
+	appendPromptField(&b, "Status", firstNonEmpty(req.Status, settings.DefaultStatus))
+	appendPromptField(&b, "Author", firstNonEmpty(req.Author, settings.DefaultAuthor))
+	appendPromptField(&b, "Language", firstNonEmpty(req.Lang, settings.DefaultLang))
+	appendPromptField(&b, "Summary", req.Summary)
+	appendPromptList(&b, "Tags", req.Tags)
+	appendPromptList(&b, "Categories", req.Categories)
+	b.WriteString("\nUser prompt:\n")
+	b.WriteString(strings.TrimSpace(req.Prompt))
+	b.WriteString("\n")
+	return b.String()
+}
+
+func completeMarkdownDocument(markdown string, settings Settings, req GenerateRequest) (string, string, string, string) {
+	title := firstNonEmpty(req.Title, frontmatterValue(markdown, "title"), titleFromPrompt(req.Prompt))
+	slug := slugify(firstNonEmpty(req.Slug, frontmatterValue(markdown, "slug"), title))
+	status := lowerString(firstNonEmpty(req.Status, frontmatterValue(markdown, "status"), settings.DefaultStatus, defaultGeneratedStatus))
+	author := firstNonEmpty(req.Author, frontmatterValue(markdown, "author"), settings.DefaultAuthor)
+	lang := firstNonEmpty(req.Lang, frontmatterValue(markdown, "lang"), settings.DefaultLang)
+	summary := firstNonEmpty(req.Summary, frontmatterValue(markdown, "summary"))
+
+	if hasFrontmatter(markdown) {
+		return markAIGenerated(markdown, settings), title, slug, status
+	}
+
+	var b strings.Builder
+	b.WriteString("---\n")
+	writeYAMLString(&b, "title", title)
+	writeYAMLString(&b, "slug", slug)
+	writeYAMLString(&b, "date", time.Now().UTC().Format(time.RFC3339))
+	writeYAMLString(&b, "status", status)
+	if summary != "" {
+		writeYAMLString(&b, "summary", summary)
+	}
+	writeYAMLList(&b, "tags", req.Tags)
+	writeYAMLList(&b, "categories", req.Categories)
+	if author != "" {
+		writeYAMLString(&b, "author", author)
+	}
+	if lang != "" {
+		writeYAMLString(&b, "lang", lang)
+	}
+	writeYAMLString(&b, "layout", "post")
+	writeYAMLBool(&b, "ai_generated", true)
+	writeYAMLString(&b, "ai_provider", settings.Provider)
+	writeYAMLString(&b, "ai_model", settings.Model)
+	writeYAMLString(&b, "ai_generated_at", time.Now().UTC().Format(time.RFC3339))
+	b.WriteString("---\n\n")
+	b.WriteString(strings.TrimSpace(markdown))
+	b.WriteString("\n")
+	return b.String(), title, slug, status
+}
+
+func markAIGenerated(markdown string, settings Settings) string {
+	if !hasFrontmatter(markdown) || frontmatterValue(markdown, "ai_generated") != "" {
+		return markdown
+	}
+	var b strings.Builder
+	b.WriteString("---\n")
+	writeYAMLBool(&b, "ai_generated", true)
+	writeYAMLString(&b, "ai_provider", settings.Provider)
+	writeYAMLString(&b, "ai_model", settings.Model)
+	writeYAMLString(&b, "ai_generated_at", time.Now().UTC().Format(time.RFC3339))
+	return strings.Replace(markdown, "---\n", b.String(), 1)
+}
+
+func writePost(cfg *config.Config, markdown string) (string, error) {
+	if cfg == nil {
+		return "", fmt.Errorf("config is required")
+	}
+	contentRoot := strings.TrimSpace(cfg.ContentDir)
+	if contentRoot == "" {
+		contentRoot = "content"
+	}
+	postsDir := strings.TrimSpace(cfg.Content.PostsDir)
+	if postsDir == "" {
+		postsDir = "posts"
+	}
+	postsRoot, err := safepath.ResolveRelativeUnderRoot(contentRoot, postsDir)
+	if err != nil {
+		return "", err
+	}
+	if err := os.MkdirAll(postsRoot, 0o755); err != nil {
+		return "", err
+	}
+
+	baseName := "ai-post-" + time.Now().UTC().Format("20060102-150405")
+	for i := 0; i < 1000; i++ {
+		name := baseName + ".md"
+		if i > 0 {
+			name = baseName + "-" + strconv.Itoa(i+1) + ".md"
+		}
+		target, err := safepath.ResolveRelativeUnderRoot(postsRoot, name)
+		if err != nil {
+			return "", err
+		}
+		if _, err := os.Stat(target); err == nil {
+			continue
+		} else if !os.IsNotExist(err) {
+			return "", err
+		}
+		if err := os.WriteFile(target, []byte(markdown), 0o644); err != nil {
+			return "", err
+		}
+		return target, nil
+	}
+	return "", fmt.Errorf("could not allocate a unique post filename")
+}
+
+func countAIWrittenPosts(cfg *config.Config) int {
+	root, err := postsRoot(cfg)
+	if err != nil {
+		return 0
+	}
+	count := 0
+	_ = filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil || d == nil || d.IsDir() || !strings.HasSuffix(strings.ToLower(d.Name()), ".md") {
+			return nil
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return nil
+		}
+		target, err := safepath.ResolveRelativeUnderRoot(root, rel)
+		if err != nil {
+			return nil
+		}
+		b, err := os.ReadFile(target)
+		if err != nil {
+			return nil
+		}
+		if strings.EqualFold(frontmatterValue(string(b), "ai_generated"), "true") {
+			count++
+		}
+		return nil
+	})
+	return count
+}
+
+func postsRoot(cfg *config.Config) (string, error) {
+	if cfg == nil {
+		return "", fmt.Errorf("config is required")
+	}
+	contentRoot := strings.TrimSpace(cfg.ContentDir)
+	if contentRoot == "" {
+		contentRoot = "content"
+	}
+	postsDir := strings.TrimSpace(cfg.Content.PostsDir)
+	if postsDir == "" {
+		postsDir = "posts"
+	}
+	return safepath.ResolveRelativeUnderRoot(contentRoot, postsDir)
+}
+
+func normalizeMarkdown(input string) string {
+	out := strings.TrimSpace(input)
+	if strings.HasPrefix(out, "```") {
+		lines := strings.Split(out, "\n")
+		if len(lines) >= 2 {
+			first := strings.TrimSpace(lines[0])
+			last := strings.TrimSpace(lines[len(lines)-1])
+			if strings.HasPrefix(first, "```") && strings.HasPrefix(last, "```") {
+				out = strings.Join(lines[1:len(lines)-1], "\n")
+			}
+		}
+	}
+	return strings.TrimSpace(out) + "\n"
+}
+
+func slugify(input string) string {
+	input = strings.ToLower(strings.TrimSpace(input))
+	var b strings.Builder
+	lastDash := false
+	for _, r := range input {
+		switch {
+		case unicode.IsLetter(r) || unicode.IsDigit(r):
+			b.WriteRune(r)
+			lastDash = false
+		case r == '-' || r == '_' || unicode.IsSpace(r):
+			if !lastDash && b.Len() > 0 {
+				b.WriteByte('-')
+				lastDash = true
+			}
+		}
+	}
+	return strings.Trim(b.String(), "-")
+}
+
+func hasFrontmatter(markdown string) bool {
+	markdown = strings.TrimSpace(markdown)
+	if !strings.HasPrefix(markdown, "---\n") {
+		return false
+	}
+	return strings.Contains(markdown[4:], "\n---")
+}
+
+func frontmatterValue(markdown, key string) string {
+	if !hasFrontmatter(markdown) {
+		return ""
+	}
+	end := strings.Index(strings.TrimPrefix(markdown, "---\n"), "\n---")
+	if end < 0 {
+		return ""
+	}
+	block := strings.TrimPrefix(markdown, "---\n")[:end]
+	for _, match := range frontmatterValuePattern.FindAllStringSubmatch(block, -1) {
+		if strings.EqualFold(match[1], key) {
+			return strings.TrimSpace(strings.Trim(match[2], `"'`))
+		}
+	}
+	return ""
+}
+
+func endpointWithQueryKey(endpoint, key string) (string, error) {
+	u, err := url.Parse(endpoint)
+	if err != nil {
+		return "", err
+	}
+	query := u.Query()
+	if query.Get("key") == "" {
+		query.Set("key", key)
+	}
+	u.RawQuery = query.Encode()
+	return u.String(), nil
+}
+
+func requireText(text, provider string) (string, error) {
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return "", fmt.Errorf("%s response did not include generated text", provider)
+	}
+	return text, nil
+}
+
+func writeJSON(w http.ResponseWriter, status int, payload any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(payload)
+}
+
+func writeJSONError(w http.ResponseWriter, status int, err error) {
+	message := "request failed"
+	if err != nil {
+		message = err.Error()
+	}
+	writeJSON(w, status, map[string]string{"message": message})
+}
+
+func settingString(values map[string]any, key, fallback string) string {
+	if values == nil {
+		return fallback
+	}
+	switch v := values[key].(type) {
+	case string:
+		if strings.TrimSpace(v) != "" {
+			return strings.TrimSpace(v)
+		}
+	case fmt.Stringer:
+		if strings.TrimSpace(v.String()) != "" {
+			return strings.TrimSpace(v.String())
+		}
+	}
+	return fallback
+}
+
+func settingInt(values map[string]any, key string, fallback int) int {
+	switch v := values[key].(type) {
+	case int:
+		return v
+	case int64:
+		return int(v)
+	case float64:
+		return int(v)
+	case string:
+		if parsed, err := strconv.Atoi(strings.TrimSpace(v)); err == nil {
+			return parsed
+		}
+	}
+	return fallback
+}
+
+func settingFloat(values map[string]any, key string, fallback float64) float64 {
+	switch v := values[key].(type) {
+	case float64:
+		return v
+	case float32:
+		return float64(v)
+	case int:
+		return float64(v)
+	case string:
+		if parsed, err := strconv.ParseFloat(strings.TrimSpace(v), 64); err == nil {
+			return parsed
+		}
+	}
+	return fallback
+}
+
+func defaultAPIKeyEnv(provider string) string {
+	switch strings.ToLower(strings.TrimSpace(provider)) {
+	case "anthropic", "claude":
+		return "ANTHROPIC_API_KEY"
+	case "gemini", "google":
+		return "GEMINI_API_KEY"
+	default:
+		return "OPENAI_API_KEY"
+	}
+}
+
+func isValidEnvVarName(value string) bool {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return false
+	}
+	for i, r := range value {
+		if i == 0 && !(r == '_' || unicode.IsLetter(r)) {
+			return false
+		}
+		if !(r == '_' || unicode.IsLetter(r) || unicode.IsDigit(r)) {
+			return false
+		}
+	}
+	return true
+}
+
+func defaultModel(provider string) string {
+	switch strings.ToLower(strings.TrimSpace(provider)) {
+	case "anthropic", "claude":
+		return defaultAnthropicModel
+	case "gemini", "google":
+		return defaultGeminiModel
+	default:
+		return defaultOpenAIModel
+	}
+}
+
+func defaultVersion(provider string) string {
+	switch strings.ToLower(strings.TrimSpace(provider)) {
+	case "anthropic", "claude":
+		return defaultAnthropicVersion
+	case "gemini", "google":
+		return defaultGeminiVersion
+	default:
+		return defaultOpenAIVersion
+	}
+}
+
+func normalizedEndpointVersion(provider, version string) string {
+	version = strings.TrimSpace(version)
+	if version != "" {
+		return version
+	}
+	return defaultVersion(provider)
+}
+
+func resolveEndpoint(provider, model, endpointOverride, endpointVersionValue string) string {
+	endpointOverride = strings.TrimSpace(endpointOverride)
+	if endpointOverride == "" {
+		return defaultEndpoint(provider, model, endpointVersionValue)
+	}
+	return strings.ReplaceAll(endpointOverride, "{version}", normalizedEndpointVersion(provider, endpointVersionValue))
+}
+
+func defaultEndpoint(provider, model, endpointVersionValue string) string {
+	switch strings.ToLower(strings.TrimSpace(provider)) {
+	case "anthropic", "claude":
+		return strings.ReplaceAll(defaultAnthropicURL, "{version}", normalizedEndpointVersion(provider, endpointVersionValue))
+	case "gemini", "google":
+		endpoint := strings.ReplaceAll(defaultGeminiEndpoint, "{version}", normalizedEndpointVersion(provider, endpointVersionValue))
+		return fmt.Sprintf(endpoint, url.PathEscape(firstNonEmpty(model, defaultGeminiModel)))
+	default:
+		return strings.ReplaceAll(defaultOpenAIEndpoint, "{version}", normalizedEndpointVersion(provider, endpointVersionValue))
+	}
+}
+
+func lowerString(value string) string {
+	return strings.ToLower(strings.TrimSpace(value))
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}
+
+func appendPromptField(b *strings.Builder, label, value string) {
+	if strings.TrimSpace(value) == "" {
+		return
+	}
+	b.WriteString("- ")
+	b.WriteString(label)
+	b.WriteString(": ")
+	b.WriteString(strings.TrimSpace(value))
+	b.WriteString("\n")
+}
+
+func appendPromptList(b *strings.Builder, label string, values []string) {
+	cleaned := cleanStringList(values)
+	if len(cleaned) == 0 {
+		return
+	}
+	appendPromptField(b, label, strings.Join(cleaned, ", "))
+}
+
+func writeYAMLString(b *strings.Builder, key, value string) {
+	b.WriteString(key)
+	b.WriteString(": ")
+	b.WriteString(strconv.Quote(strings.TrimSpace(value)))
+	b.WriteString("\n")
+}
+
+func writeYAMLBool(b *strings.Builder, key string, value bool) {
+	b.WriteString(key)
+	if value {
+		b.WriteString(": true\n")
+		return
+	}
+	b.WriteString(": false\n")
+}
+
+func writeYAMLList(b *strings.Builder, key string, values []string) {
+	cleaned := cleanStringList(values)
+	if len(cleaned) == 0 {
+		b.WriteString(key)
+		b.WriteString(": []\n")
+		return
+	}
+	b.WriteString(key)
+	b.WriteString(":\n")
+	for _, value := range cleaned {
+		b.WriteString("  - ")
+		b.WriteString(strconv.Quote(value))
+		b.WriteString("\n")
+	}
+}
+
+func cleanStringList(values []string) []string {
+	out := make([]string, 0, len(values))
+	seen := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		key := strings.ToLower(value)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, value)
+	}
+	return out
+}
+
+func titleFromPrompt(prompt string) string {
+	fields := strings.Fields(strings.TrimSpace(prompt))
+	if len(fields) == 0 {
+		return "AI Generated Post"
+	}
+	if len(fields) > 8 {
+		fields = fields[:8]
+	}
+	title := strings.Join(fields, " ")
+	title = strings.Trim(title, ".,:;!?\"'")
+	if title == "" {
+		return "AI Generated Post"
+	}
+	return title
+}
+
+func init() {
+	plugins.Register(pluginName, func() plugins.Plugin { return New() })
+}

--- a/plugins/aiwriter/plugin.yaml
+++ b/plugins/aiwriter/plugin.yaml
@@ -1,0 +1,119 @@
+name: aiwriter
+title: AI Writer
+version: 0.1.0
+description: Generates Markdown draft posts from admin-provided prompts using OpenAI, Anthropic Claude, or Google Gemini.
+author: Foundry
+homepage: https://github.com/sphireinc/foundry/plugins/aiwriter
+license: MIT
+repo: github.com/sphireinc/foundry/plugins/aiwriter
+foundry_api: v1
+min_foundry_version: 1.3.9
+compatibility_version: v1
+config_schema:
+  - name: params.ai_writer.provider
+    label: Provider
+    type: string
+    default: openai
+    enum:
+      - openai
+      - anthropic
+      - gemini
+    help: AI provider used for post generation.
+  - name: params.ai_writer.api_key_env
+    label: API key environment variable
+    type: string
+    default: OPENAI_API_KEY
+    help: Environment variable that stores the provider API key.
+  - name: params.ai_writer.model
+    label: Model
+    type: string
+    default: gpt-4o-mini
+    help: Provider model name.
+  - name: params.ai_writer.endpoint
+    label: Endpoint override
+    type: string
+    help: Optional provider endpoint override for gateways or tests.
+  - name: params.ai_writer.endpoint_version
+    label: Endpoint version
+    type: string
+    help: API endpoint version used in default endpoints, or in custom endpoints containing {version}.
+  - name: params.ai_writer.temperature
+    label: Temperature
+    type: number
+    default: 0.7
+    help: Provider sampling temperature.
+  - name: params.ai_writer.max_tokens
+    label: Max tokens
+    type: number
+    default: 2400
+    help: Maximum output token budget.
+  - name: params.ai_writer.timeout_seconds
+    label: Timeout seconds
+    type: number
+    default: 60
+    help: HTTP timeout for provider requests.
+  - name: params.ai_writer.default_status
+    label: Default status
+    type: string
+    default: draft
+    help: Default frontmatter status for generated posts.
+  - name: params.ai_writer.default_author
+    label: Default author
+    type: string
+    help: Default frontmatter author.
+  - name: params.ai_writer.default_lang
+    label: Default language
+    type: string
+    help: Default frontmatter language.
+  - name: params.ai_writer.system_prompt
+    label: System prompt
+    type: text
+    help: Site-specific writing instructions appended to the built-in Foundry prompt.
+permissions:
+  filesystem:
+    read:
+      content: true
+    write:
+      content: true
+  network:
+    outbound:
+      https: true
+      domains:
+        - api.openai.com
+        - api.anthropic.com
+        - generativelanguage.googleapis.com
+      methods:
+        - POST
+    inbound:
+      register_routes: true
+      admin_routes: true
+  environment:
+    read:
+      allowed: true
+      variables:
+        - OPENAI_API_KEY
+        - ANTHROPIC_API_KEY
+        - GEMINI_API_KEY
+  config:
+    read:
+      site: true
+      plugin_config: true
+  content:
+    documents:
+      write: true
+  admin:
+    extensions:
+      pages: true
+  capabilities:
+    requires_admin_approval: true
+admin:
+  pages:
+    - key: ai-writer
+      title: AI Writer
+      route: /plugins/aiwriter
+      nav_group: content
+      capability: documents.create
+      description: Generate draft Markdown posts with an AI provider configured on the server.
+      module: assets/admin.js
+      styles:
+        - assets/admin.css

--- a/plugins/aiwriter/plugin_test.go
+++ b/plugins/aiwriter/plugin_test.go
@@ -1,0 +1,366 @@
+package aiwriter
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/sphireinc/foundry/internal/config"
+)
+
+func TestSettingsFromConfig(t *testing.T) {
+	cfg := &config.Config{
+		DefaultLang: "en",
+		Params: map[string]any{
+			"ai_writer": map[string]any{
+				"provider":         "gemini",
+				"api_key_env":      "CUSTOM_GEMINI_KEY",
+				"model":            "gemini-2.0-flash",
+				"endpoint_version": "v1",
+				"temperature":      0.4,
+				"max_tokens":       1200,
+				"timeout_seconds":  12,
+				"default_status":   "review",
+			},
+		},
+	}
+
+	settings := settingsFromConfig(cfg)
+	if settings.Provider != "gemini" {
+		t.Fatalf("expected gemini provider, got %q", settings.Provider)
+	}
+	if settings.APIKeyEnv != "CUSTOM_GEMINI_KEY" {
+		t.Fatalf("expected custom key env, got %q", settings.APIKeyEnv)
+	}
+	if settings.Model != "gemini-2.0-flash" {
+		t.Fatalf("expected configured model, got %q", settings.Model)
+	}
+	if settings.EndpointVersion != "v1" {
+		t.Fatalf("expected configured endpoint version, got %q", settings.EndpointVersion)
+	}
+	if settings.Endpoint != "https://generativelanguage.googleapis.com/v1/models/gemini-2.0-flash:generateContent" {
+		t.Fatalf("unexpected endpoint: %q", settings.Endpoint)
+	}
+	if settings.DefaultStatus != "review" {
+		t.Fatalf("expected review default status, got %q", settings.DefaultStatus)
+	}
+	if settings.DefaultLang != "en" {
+		t.Fatalf("expected default language from config, got %q", settings.DefaultLang)
+	}
+}
+
+func TestDefaultEndpointVersions(t *testing.T) {
+	tests := []struct {
+		name     string
+		provider string
+		model    string
+		version  string
+		want     string
+	}{
+		{
+			name:     "openai default",
+			provider: "openai",
+			model:    "gpt-test",
+			want:     "https://api.openai.com/v1/responses",
+		},
+		{
+			name:     "openai override",
+			provider: "openai",
+			model:    "gpt-test",
+			version:  "v2",
+			want:     "https://api.openai.com/v2/responses",
+		},
+		{
+			name:     "anthropic default",
+			provider: "anthropic",
+			model:    "claude-test",
+			want:     "https://api.anthropic.com/v1/messages",
+		},
+		{
+			name:     "gemini default",
+			provider: "gemini",
+			model:    "gemini test/model",
+			want:     "https://generativelanguage.googleapis.com/v1beta/models/gemini%20test%2Fmodel:generateContent",
+		},
+		{
+			name:     "gemini override",
+			provider: "gemini",
+			model:    "gemini-test",
+			version:  "v1",
+			want:     "https://generativelanguage.googleapis.com/v1/models/gemini-test:generateContent",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := defaultEndpoint(tt.provider, tt.model, tt.version); got != tt.want {
+				t.Fatalf("defaultEndpoint() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveEndpointAppliesVersionPlaceholderToOverrides(t *testing.T) {
+	got := resolveEndpoint("openai", "ignored", "https://gateway.example/{version}/responses", "v9")
+	if got != "https://gateway.example/v9/responses" {
+		t.Fatalf("unexpected endpoint override: %q", got)
+	}
+	got = resolveEndpoint("openai", "ignored", "https://gateway.example/static", "v9")
+	if got != "https://gateway.example/static" {
+		t.Fatalf("unexpected static endpoint override: %q", got)
+	}
+}
+
+func TestSettingsFromConfigTreatsInvalidAPIKeyEnvAsInlineKey(t *testing.T) {
+	cfg := &config.Config{
+		Params: map[string]any{
+			"ai_writer": map[string]any{
+				"provider":    "openai",
+				"api_key_env": "sk-test-temporary-key",
+			},
+		},
+	}
+
+	settings := settingsFromConfig(cfg)
+	if settings.APIKey != "sk-test-temporary-key" {
+		t.Fatal("expected invalid api_key_env value to be treated as inline API key")
+	}
+	if settings.APIKeyEnv != "OPENAI_API_KEY" {
+		t.Fatalf("expected api_key_env to reset to default env var name, got %q", settings.APIKeyEnv)
+	}
+	key, source := settings.resolveAPIKey()
+	if key == "" || source != "config" {
+		t.Fatalf("expected config key source, got key-present=%v source=%q", key != "", source)
+	}
+}
+
+func TestIsValidEnvVarName(t *testing.T) {
+	for _, value := range []string{"OPENAI_API_KEY", "_PRIVATE_KEY", "A1"} {
+		if !isValidEnvVarName(value) {
+			t.Fatalf("expected %q to be valid", value)
+		}
+	}
+	for _, value := range []string{"", "1OPENAI", "sk-test-key", "OPENAI API KEY"} {
+		if isValidEnvVarName(value) {
+			t.Fatalf("expected %q to be invalid", value)
+		}
+	}
+}
+
+func TestBuildPromptWrapsUserPromptWithFoundryInstructions(t *testing.T) {
+	prompt := buildPrompt(Settings{DefaultStatus: "draft", DefaultLang: "en"}, GenerateRequest{
+		Prompt: "Write about launch checklists.",
+		Title:  "Launch checklist",
+		Tags:   []string{"cms", "launch"},
+	})
+
+	for _, want := range []string{
+		"Foundry, a Markdown-driven CMS written in Go",
+		"Return exactly one complete Markdown post",
+		"Title: Launch checklist",
+		"Tags: cms, launch",
+		"Write about launch checklists.",
+	} {
+		if !strings.Contains(prompt, want) {
+			t.Fatalf("prompt missing %q:\n%s", want, prompt)
+		}
+	}
+}
+
+func TestCompleteMarkdownDocumentAddsFrontmatter(t *testing.T) {
+	markdown, title, slug, status := completeMarkdownDocument("# Body\n\nHello.", Settings{
+		DefaultStatus: "draft",
+		DefaultAuthor: "Foundry Team",
+		DefaultLang:   "en",
+	}, GenerateRequest{
+		Title:      "A Useful Post",
+		Prompt:     "A useful post",
+		Tags:       []string{"one", "two"},
+		Categories: []string{"Guides"},
+	})
+
+	if title != "A Useful Post" || slug != "a-useful-post" || status != "draft" {
+		t.Fatalf("unexpected metadata title=%q slug=%q status=%q", title, slug, status)
+	}
+	for _, want := range []string{
+		"---\n",
+		`title: "A Useful Post"`,
+		`slug: "a-useful-post"`,
+		`author: "Foundry Team"`,
+		`lang: "en"`,
+		`layout: "post"`,
+		"ai_generated: true",
+		"# Body",
+	} {
+		if !strings.Contains(markdown, want) {
+			t.Fatalf("markdown missing %q:\n%s", want, markdown)
+		}
+	}
+}
+
+func TestRequestOpenAI(t *testing.T) {
+	var sawPrompt string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer test-key" {
+			t.Fatalf("unexpected auth header %q", got)
+		}
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatal(err)
+		}
+		sawPrompt, _ = body["input"].(string)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"output_text":"---\ntitle: Generated\n---\n\n# Generated\n","usage":{"input_tokens":11,"output_tokens":17,"total_tokens":28}}`))
+	}))
+	defer server.Close()
+
+	got, usage, err := requestCompletion(context.Background(), server.Client(), Settings{
+		Provider:    "openai",
+		APIKey:      "test-key",
+		Model:       "test-model",
+		Endpoint:    server.URL,
+		Temperature: 0.2,
+		MaxTokens:   200,
+	}, "wrapped prompt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(got, "# Generated") {
+		t.Fatalf("unexpected generated markdown: %s", got)
+	}
+	if usage.TotalTokens != 28 || usage.PromptTokens != 11 || usage.CompletionTokens != 17 {
+		t.Fatalf("unexpected usage: %#v", usage)
+	}
+	if sawPrompt != "wrapped prompt" {
+		t.Fatalf("unexpected prompt %q", sawPrompt)
+	}
+}
+
+func TestRequestAnthropic(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("x-api-key"); got != "test-key" {
+			t.Fatalf("unexpected api key header %q", got)
+		}
+		if got := r.Header.Get("anthropic-version"); got == "" {
+			t.Fatal("expected anthropic-version header")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"content":[{"type":"text","text":"# Claude Post"}],"usage":{"input_tokens":13,"output_tokens":21}}`))
+	}))
+	defer server.Close()
+
+	got, usage, err := requestCompletion(context.Background(), server.Client(), Settings{
+		Provider:    "anthropic",
+		APIKey:      "test-key",
+		Model:       "claude-test",
+		Endpoint:    server.URL,
+		Temperature: 0.2,
+		MaxTokens:   200,
+	}, "wrapped prompt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "# Claude Post" {
+		t.Fatalf("unexpected generated markdown: %s", got)
+	}
+	if usage.TotalTokens != 34 || usage.PromptTokens != 13 || usage.CompletionTokens != 21 {
+		t.Fatalf("unexpected usage: %#v", usage)
+	}
+}
+
+func TestRequestGemini(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get("key"); got != "test-key" {
+			t.Fatalf("unexpected query key %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"candidates":[{"content":{"parts":[{"text":"# Gemini Post"}]}}],"usageMetadata":{"promptTokenCount":9,"candidatesTokenCount":14,"totalTokenCount":23}}`))
+	}))
+	defer server.Close()
+
+	got, usage, err := requestCompletion(context.Background(), server.Client(), Settings{
+		Provider:    "gemini",
+		APIKey:      "test-key",
+		Model:       "gemini-test",
+		Endpoint:    server.URL,
+		Temperature: 0.2,
+		MaxTokens:   200,
+	}, "wrapped prompt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "# Gemini Post" {
+		t.Fatalf("unexpected generated markdown: %s", got)
+	}
+	if usage.TotalTokens != 23 || usage.PromptTokens != 9 || usage.CompletionTokens != 14 {
+		t.Fatalf("unexpected usage: %#v", usage)
+	}
+}
+
+func TestGenerateAndWriteCreatesUniquePost(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"output_text":"# Body\n\nGenerated content.","usage":{"input_tokens":3,"output_tokens":4,"total_tokens":7}}`))
+	}))
+	defer server.Close()
+
+	tmp := t.TempDir()
+	cfg := &config.Config{
+		ContentDir: tmp,
+		Content:    config.ContentConfig{PostsDir: "posts"},
+		Params: map[string]any{
+			"ai_writer": map[string]any{
+				"provider": "openai",
+				"api_key":  "test-key",
+				"model":    "test-model",
+				"endpoint": server.URL,
+			},
+		},
+	}
+	plugin := New()
+	if err := plugin.OnConfigLoaded(cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	first, err := plugin.GenerateAndWrite(context.Background(), GenerateRequest{
+		Prompt: "Generate one post.",
+		Title:  "Generated Post",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := plugin.GenerateAndWrite(context.Background(), GenerateRequest{
+		Prompt: "Generate another post.",
+		Title:  "Generated Post",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if first.Path == second.Path {
+		t.Fatalf("expected unique paths, both were %q", first.Path)
+	}
+	for _, path := range []string{first.Path, second.Path} {
+		b, err := os.ReadFile(filepath.Clean(path))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(string(b), `title: "Generated Post"`) {
+			t.Fatalf("generated file missing frontmatter: %s", string(b))
+		}
+		if !strings.Contains(string(b), "ai_generated: true") {
+			t.Fatalf("generated file missing AI marker: %s", string(b))
+		}
+	}
+	if count := countAIWrittenPosts(cfg); count != 2 {
+		t.Fatalf("expected 2 AI-written posts, got %d", count)
+	}
+	usage := plugin.usageSnapshot()
+	if usage.GenerationsThisRun != 2 || usage.TotalTokensThisRun != 14 {
+		t.Fatalf("unexpected process usage: %#v", usage)
+	}
+}

--- a/themes/admin-themes/default/assets/admin.js
+++ b/themes/admin-themes/default/assets/admin.js
@@ -268,10 +268,8 @@ import {
     return normalized === 'settings' || normalized === 'config';
   };
   const { extensionMountID, renderExtensionPage, renderWidgetPanels } = createExtensionViews({
-    state,
     panel,
     escapeHTML,
-    hasCapability,
     normalizeAdminSection,
     extensionPageBySection,
     extensionWidgetsForSlot,

--- a/themes/admin-themes/default/assets/admin/core/extensions-runtime.js
+++ b/themes/admin-themes/default/assets/admin/core/extensions-runtime.js
@@ -24,29 +24,38 @@ export const createExtensionsRuntime = ({
       getExtensions: () => clone(state.adminExtensions),
       getSettingsSections: () => clone(state.settingsSections),
     };
+  };
+
+  const dispatchExtensionPageEvent = (page) => {
+    if (!page) return;
+    if (state.debugTools.flags.captureExtensionEvents) {
+      recordDebugEvent('extension-page', `Dispatching extension page event for ${page.plugin}/${page.key}`, {
+        section: page.section,
+        route: page.route || '',
+      });
+    }
+    documentRef.dispatchEvent(
+      new CustomEvent('foundry:admin-extension-page', {
+        detail: {
+          page,
+          adminBase,
+          session: state.session,
+          capabilities: [...capabilitySet()],
+          settingsSections: (state.settingsSections || []).filter(
+            (section) => section.source === page.plugin
+          ),
+          extensions: clone(state.adminExtensions),
+          mountId: 'admin-extension-mount',
+        },
+      })
+    );
+  };
+
+  const publishAdminRuntimeAndDispatchActivePage = () => {
+    publishAdminRuntime();
     const page = extensionPageBySection(state.section);
     if (page) {
-      if (state.debugTools.flags.captureExtensionEvents) {
-        recordDebugEvent('extension-page', `Dispatching extension page event for ${page.plugin}/${page.key}`, {
-          section: page.section,
-          route: page.route || '',
-        });
-      }
-      documentRef.dispatchEvent(
-        new CustomEvent('foundry:admin-extension-page', {
-          detail: {
-            page,
-            adminBase,
-            session: state.session,
-            capabilities: [...capabilitySet()],
-            settingsSections: (state.settingsSections || []).filter(
-              (section) => section.source === page.plugin
-            ),
-            extensions: clone(state.adminExtensions),
-            mountId: 'admin-extension-mount',
-          },
-        })
-      );
+      dispatchExtensionPageEvent(page);
     }
   };
 
@@ -103,6 +112,7 @@ export const createExtensionsRuntime = ({
           });
         }
       } else {
+        dispatchExtensionPageEvent(page);
         mount.dataset.extensionStatus = 'ready';
       }
     } catch (error) {
@@ -222,6 +232,7 @@ export const createExtensionsRuntime = ({
 
   return {
     publishAdminRuntime,
+    publishAdminRuntimeAndDispatchActivePage,
     mountActiveExtensionPage,
     mountVisibleExtensionWidgets,
   };

--- a/themes/admin-themes/default/assets/admin/core/router.js
+++ b/themes/admin-themes/default/assets/admin/core/router.js
@@ -6,6 +6,8 @@ const sectionFromPathAliases = Object.fromEntries(
   Object.entries(sectionPathAliases).map(([section, path]) => [path, section])
 );
 
+sectionFromPathAliases['plugins/ai-writer'] = 'plugins/aiwriter';
+
 export const normalizeAdminSection = (section) => {
   const value = String(section || 'overview')
     .trim()

--- a/themes/admin-themes/default/assets/admin/views/extensions.js
+++ b/themes/admin-themes/default/assets/admin/views/extensions.js
@@ -1,8 +1,6 @@
 export const createExtensionViews = ({
-  state,
   panel,
   escapeHTML,
-  hasCapability,
   normalizeAdminSection,
   extensionPageBySection,
   extensionWidgetsForSlot,
@@ -38,15 +36,6 @@ export const createExtensionViews = ({
         '<div class="panel-pad empty-state">This admin extension page is not registered.</div>'
       );
     }
-    const relatedWidgets = (state.adminExtensions.widgets || []).filter(
-      (widget) => widget.plugin === page.plugin && hasCapability(widget.capability)
-    );
-    const relatedSettings = (state.adminExtensions.settings || []).filter(
-      (setting) => setting.plugin === page.plugin && hasCapability(setting.capability)
-    );
-    const relatedSlots = (state.adminExtensions.slots || []).filter(
-      (slot) => slot.plugin === page.plugin
-    );
     return panel(
       page.title,
       `
@@ -54,52 +43,6 @@ export const createExtensionViews = ({
         <div class="note">
           <strong>${escapeHTML(page.plugin)}</strong>${page.description ? ` • ${escapeHTML(page.description)}` : ''}
         </div>
-        <div class="cards">
-          <article class="card"><span class="card-label">Route</span><strong>${escapeHTML(page.route || `/${page.section}`)}</strong><span class="card-copy">Mounted from plugin metadata.</span></article>
-          <article class="card"><span class="card-label">Widgets</span><strong>${escapeHTML(relatedWidgets.length)}</strong><span class="card-copy">Plugin widgets registered for admin slots.</span></article>
-          <article class="card"><span class="card-label">Settings</span><strong>${escapeHTML(relatedSettings.length)}</strong><span class="card-copy">Plugin settings sections exposed to admin.</span></article>
-          <article class="card"><span class="card-label">Slots</span><strong>${escapeHTML(relatedSlots.length)}</strong><span class="card-copy">Declared admin shell slots.</span></article>
-        </div>
-        ${
-          relatedSettings.length
-            ? `<div class="stack">
-          <h3>Settings Sections</h3>
-          <div class="table table-three">
-            <div class="table-head"><span>Section</span><span>Capability</span><span>Description</span></div>
-            ${relatedSettings
-              .map(
-                (setting) => `
-              <div class="table-row">
-                <span><strong>${escapeHTML(setting.title)}</strong><div class="muted mono">${escapeHTML(setting.key)}</div></span>
-                <span>${escapeHTML(setting.capability || '-')}</span>
-                <span>${escapeHTML(setting.description || '-')}</span>
-              </div>`
-              )
-              .join('')}
-          </div>
-        </div>`
-            : ''
-        }
-        ${
-          relatedWidgets.length
-            ? `<div class="stack">
-          <h3>Widgets</h3>
-          <div class="table table-three">
-            <div class="table-head"><span>Widget</span><span>Slot</span><span>Description</span></div>
-            ${relatedWidgets
-              .map(
-                (widget) => `
-              <div class="table-row">
-                <span><strong>${escapeHTML(widget.title)}</strong><div class="muted mono">${escapeHTML(widget.key)}</div></span>
-                <span>${escapeHTML(widget.slot)}</span>
-                <span>${escapeHTML(widget.description || '-')}</span>
-              </div>`
-              )
-              .join('')}
-          </div>
-        </div>`
-            : ''
-        }
         <div id="admin-extension-mount"
              class="admin-extension-mount"
              data-plugin="${escapeHTML(page.plugin)}"

--- a/themes/admin-themes/default/assets/admin/views/platform.js
+++ b/themes/admin-themes/default/assets/admin/views/platform.js
@@ -149,14 +149,23 @@ export const createPlatformViews = ({
         ? `<div class="panel-pad stack">
       <h3>Extension Pages</h3>
       <div class="table table-three">
-        <div class="table-head"><span>Page</span><span>Route</span><span>Plugin</span></div>
+        <div class="table-head">
+            <span>Menu Name</span>
+            <span>Action</span>
+            <span>Route</span>
+        </div>
         ${extensionPages()
           .map(
             (page) => `
           <div class="table-row table-row-actions">
-            <span><strong>${escapeHTML(page.title)}</strong><div class="muted mono">${escapeHTML(page.key)}</div></span>
+            <span>
+                <strong>${escapeHTML(page.title)}</strong>
+                <div class="muted mono">page: /plugins/${escapeHTML(page.key)}</div>
+                <div class="muted mono">plugin: ${escapeHTML(page.plugin)}</div>
+            </span>
+            <span class="row-actions"><button class="ghost small" type="button" data-section="${escapeHTML(page.section)}">Open</button></span>
+            
             <span>${escapeHTML(adminPathForSection(adminBase, page.section))}</span>
-            <span class="row-actions"><span>${escapeHTML(page.plugin)}</span><button class="ghost small" type="button" data-section="${escapeHTML(page.section)}">Open</button></span>
           </div>`
           )
           .join('')}


### PR DESCRIPTION
## Summary

Add an AI Writer plugin that generates Foundry Markdown posts from admin-provided prompts using a configured AI provider.

## What changed

- Added a new aiwriter plugin with support for OpenAI, Anthropic Claude, and Google Gemini.
- Added an authenticated Admin UI page for writing prompts, setting post metadata, previewing generated Markdown, and creating posts.
- Added server-side provider calls so API keys stay out of browser JavaScript.
- Added configurable provider settings including API key source, model, endpoint override, endpoint version, temperature, token limit, timeout, default author, default language, default status, and system
  prompt.
- Added AI provenance frontmatter to generated posts, including ai_generated, ai_provider, ai_model, and ai_generated_at.
- Added AI Writer usage stats in the Admin UI, including AI-written post count, current-process generation count, current-process token totals, and last-request token usage.
- Added provider token usage parsing for OpenAI, Anthropic, and Gemini responses.
- Added path-safe post writing with server-generated filenames and overwrite protection.
- Added plugin metadata, permission declarations, config schema, README documentation, admin JS/CSS assets, and tests.

## Why

This gives Foundry users a first-party way to create draft Markdown posts from AI prompts while keeping provider credentials server-side, preserving content as normal file-based Markdown, and making AI-generated
content auditable through durable frontmatter metadata.

## Testing

Describe how this was tested.

- [ ] `go test ./...`
- [ ] `go vet ./...`
- [ ] `go run ./cmd/plugin-sync`
- [ ] Manual testing performed
- [ ] Added or updated tests where appropriate

## Screenshots or output

Include screenshots, logs, or terminal output if relevant.

## Checklist

- [ ] I have read the contributing guidelines
- [ ] I have kept this PR focused in scope
- [ ] I have updated documentation if needed
- [ ] I have updated generated/plugin-related files if needed
- [ ] This change does not introduce known security issues