### PR TITLE
Adds managed mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ assessment-*.txt
 Foundry-Cloud-API
 Foundry-Cloud-Dashboard
 Foundry-Cloud-Landing
+roadmap-v2
 
 ### Foundry Internal
 .foundry/

--- a/internal/commands/doctor/doctor.go
+++ b/internal/commands/doctor/doctor.go
@@ -68,6 +68,11 @@ func (command) Run(cfg *foundryconfig.Config, _ []string) error {
 	} else {
 		add("config", false, fmt.Sprintf("%d validation error(s)", len(errs)))
 	}
+	if cfg.ManagedRuntimeEnabled() {
+		add("managed_runtime", true, "enabled")
+	} else {
+		add("managed_runtime", true, "disabled")
+	}
 
 	checkDir := func(label, path string) {
 		info, err := os.Stat(path)

--- a/internal/commands/version/metadata.go
+++ b/internal/commands/version/metadata.go
@@ -31,6 +31,7 @@ type Metadata struct {
 	NearestTag     string `json:"nearest_tag,omitempty"`
 	CommitCount    int    `json:"commit_count,omitempty"`
 	Dirty          bool   `json:"dirty,omitempty"`
+	ManagedRuntime bool   `json:"managed_runtime"`
 }
 
 func Current(projectDir string) Metadata {
@@ -42,6 +43,9 @@ func Current(projectDir string) Metadata {
 		GOOS:        runtime.GOOS,
 		GOARCH:      runtime.GOARCH,
 		InstallMode: string(installmode.Detect(projectDir)),
+		ManagedRuntime: envBool("FOUNDRY_MANAGED_RUNTIME") ||
+			envBool("FOUNDRY_MANAGED_ENABLED") ||
+			envBool("FOUNDRY_CLOUD_MANAGED"),
 	}
 	if exe, err := os.Executable(); err == nil {
 		meta.Executable = exe
@@ -122,6 +126,7 @@ func (m Metadata) String() string {
 		fmt.Sprintf("Go: %s", m.GoVersion),
 		fmt.Sprintf("Target: %s/%s", m.GOOS, m.GOARCH),
 		fmt.Sprintf("Install mode: %s", m.InstallMode),
+		fmt.Sprintf("Managed runtime: %s", boolLabel(m.ManagedRuntime, "enabled", "disabled")),
 	}
 	if m.Executable != "" {
 		lines = append(lines, fmt.Sprintf("Executable: %s", m.Executable))
@@ -144,6 +149,15 @@ func (m Metadata) String() string {
 		lines = append(lines, fmt.Sprintf("Local changes: %s", boolLabel(m.Dirty, "dirty", "clean")))
 	}
 	return strings.Join(lines, "\n")
+}
+
+func envBool(name string) bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(name))) {
+	case "1", "t", "true", "y", "yes", "on", "enabled":
+		return true
+	default:
+		return false
+	}
 }
 
 func (m Metadata) ShortString() string {

--- a/internal/commands/version/version_test.go
+++ b/internal/commands/version/version_test.go
@@ -40,3 +40,14 @@ func TestEmbeddedVersionFallback(t *testing.T) {
 		t.Fatal("expected embedded version fallback to be non-empty")
 	}
 }
+
+func TestCurrentReportsManagedRuntimeFromEnvironment(t *testing.T) {
+	t.Setenv("FOUNDRY_MANAGED_RUNTIME", "true")
+	meta := Current(t.TempDir())
+	if !meta.ManagedRuntime {
+		t.Fatal("expected managed runtime metadata when env flag is set")
+	}
+	if !strings.Contains(meta.String(), "Managed runtime: enabled") {
+		t.Fatalf("expected version string to show managed runtime, got %q", meta.String())
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -14,6 +14,7 @@ type Config struct {
 	BaseURL     string                `yaml:"base_url"`
 	Theme       string                `yaml:"theme"`
 	Environment string                `yaml:"environment"`
+	Foundry     FoundryConfig         `yaml:"foundry"`
 	Admin       AdminConfig           `yaml:"admin"`
 	Backup      BackupConfig          `yaml:"backup"`
 	DefaultLang string                `yaml:"default_lang"`
@@ -36,6 +37,14 @@ type Config struct {
 	Deploy      DeployConfig          `yaml:"deploy"`
 	Params      map[string]any        `yaml:"params"`
 	Menus       map[string][]MenuItem `yaml:"menus"`
+}
+
+type FoundryConfig struct {
+	Managed ManagedRuntimeConfig `yaml:"managed"`
+}
+
+type ManagedRuntimeConfig struct {
+	Enabled bool `yaml:"enabled"`
 }
 
 type AdminConfig struct {
@@ -194,6 +203,10 @@ type MenuItem struct {
 
 func (c *Config) MarkAdminLocalOnlyExplicit() {
 	c.Admin.localOnlySet = true
+}
+
+func (c *Config) ManagedRuntimeEnabled() bool {
+	return c != nil && c.Foundry.Managed.Enabled
 }
 
 func (c *Config) ApplyDefaults() {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,8 +1,10 @@
 package config
 
 import (
+	"encoding/base64"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -224,5 +226,51 @@ func TestUnmarshalYAMLPreservesExplicitAdminLocalOnlyFalse(t *testing.T) {
 	}
 	if cfg.Admin.LocalOnly {
 		t.Fatal("expected explicit admin.local_only=false to be preserved")
+	}
+}
+
+func TestManagedRuntimeConfigValidation(t *testing.T) {
+	cfg := &Config{}
+	cfg.ApplyDefaults()
+	cfg.Foundry.Managed.Enabled = true
+	cfg.Admin.Enabled = true
+	cfg.Admin.SessionSecret = strings.Repeat("a", 32)
+	cfg.Admin.TOTPSecretKey = base64.StdEncoding.EncodeToString([]byte(strings.Repeat("b", 32)))
+	if errs := Validate(cfg); len(errs) != 0 {
+		t.Fatalf("expected managed runtime config to validate, got %v", errs)
+	}
+
+	cfg.Admin.SessionSecret = "local-dev-secret"
+	if errs := Validate(cfg); len(errs) == 0 {
+		t.Fatal("expected managed runtime to reject development session secret")
+	}
+
+	cfg.Admin.SessionSecret = strings.Repeat("a", 32)
+	cfg.Admin.TOTPSecretKey = base64.StdEncoding.EncodeToString([]byte("short"))
+	if errs := Validate(cfg); len(errs) == 0 {
+		t.Fatal("expected managed runtime to reject short TOTP key")
+	}
+}
+
+func TestManagedRuntimeConfigParsesFromYAML(t *testing.T) {
+	body := []byte("theme: default\ndefault_lang: en\ncontent_dir: content\npublic_dir: public\nthemes_dir: themes\ndata_dir: data\nplugins_dir: plugins\nfoundry:\n  managed:\n    enabled: true\nadmin:\n  enabled: true\n  session_secret: " + strings.Repeat("a", 32) + "\n  totp_secret_key: " + base64.StdEncoding.EncodeToString([]byte(strings.Repeat("b", 32))) + "\nserver:\n  addr: :8080\nfeed:\n  rss_path: /rss.xml\n  sitemap_path: /sitemap.xml\n")
+	var cfg Config
+	if err := UnmarshalYAML(body, &cfg); err != nil {
+		t.Fatalf("unmarshal managed config: %v", err)
+	}
+	if !cfg.ManagedRuntimeEnabled() {
+		t.Fatal("expected managed runtime to be enabled from YAML")
+	}
+}
+
+func TestManagedRuntimeDisabledDoesNotRequireAdminSecrets(t *testing.T) {
+	cfg := &Config{}
+	cfg.ApplyDefaults()
+	cfg.Foundry.Managed.Enabled = false
+	cfg.Admin.Enabled = true
+	cfg.Admin.SessionSecret = ""
+	cfg.Admin.TOTPSecretKey = ""
+	if errs := Validate(cfg); len(errs) != 0 {
+		t.Fatalf("expected non-managed config to allow missing admin secrets, got %v", errs)
 	}
 }

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"encoding/base64"
 	"fmt"
 	"path"
 	"regexp"
@@ -139,6 +140,9 @@ func Validate(cfg *Config) []error {
 	if strings.TrimSpace(cfg.Admin.TOTPIssuer) == "" {
 		errs = append(errs, fmt.Errorf("admin.totp_issuer must not be empty"))
 	}
+	if cfg.ManagedRuntimeEnabled() {
+		errs = append(errs, validateManagedRuntimeConfig(cfg)...)
+	}
 	for _, name := range cfg.Plugins.Enabled {
 		if strings.TrimSpace(name) == "" {
 			continue
@@ -174,4 +178,68 @@ func Validate(cfg *Config) []error {
 	}
 
 	return errs
+}
+
+func validateManagedRuntimeConfig(cfg *Config) []error {
+	var errs []error
+	if cfg == nil {
+		return []error{fmt.Errorf("foundry.managed.enabled requires config")}
+	}
+	if !cfg.Admin.Enabled {
+		errs = append(errs, fmt.Errorf("foundry.managed.enabled requires admin.enabled to be true"))
+	}
+	if err := validateManagedSecret("admin.session_secret", cfg.Admin.SessionSecret, false); err != nil {
+		errs = append(errs, err)
+	}
+	if err := validateManagedSecret("admin.totp_secret_key", cfg.Admin.TOTPSecretKey, true); err != nil {
+		errs = append(errs, err)
+	}
+	if cfg.Admin.Debug.Pprof {
+		errs = append(errs, fmt.Errorf("foundry.managed.enabled requires admin.debug.pprof to be false"))
+	}
+	return errs
+}
+
+func validateManagedSecret(name, value string, requireBase64Key bool) error {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return fmt.Errorf("foundry.managed.enabled requires %s", name)
+	}
+	if len(value) < 32 {
+		return fmt.Errorf("foundry.managed.enabled requires %s to be at least 32 characters", name)
+	}
+	normalized := strings.NewReplacer("-", "", "_", "", " ", "", ".", "").Replace(strings.ToLower(value))
+	for _, weak := range []string{
+		"localdevsecret",
+		"localruntimesecret",
+		"localsecretsencryptionkey32b",
+		"changeme",
+		"default",
+		"development",
+		"password",
+		"secret",
+		"example",
+	} {
+		if normalized == weak {
+			return fmt.Errorf("foundry.managed.enabled rejects development/default value for %s", name)
+		}
+	}
+	if requireBase64Key {
+		key, err := decodeManagedBase64Key(value)
+		if err != nil {
+			return fmt.Errorf("foundry.managed.enabled requires %s to be base64 encoded: %w", name, err)
+		}
+		if len(key) != 32 {
+			return fmt.Errorf("foundry.managed.enabled requires %s to decode to 32 bytes", name)
+		}
+	}
+	return nil
+}
+
+func decodeManagedBase64Key(raw string) ([]byte, error) {
+	raw = strings.TrimSpace(raw)
+	if key, err := base64.RawStdEncoding.DecodeString(raw); err == nil {
+		return key, nil
+	}
+	return base64.StdEncoding.DecodeString(raw)
 }


### PR DESCRIPTION
## Summary

Adds support for managed mode

## What changed

- Added foundry.managed.enabled config support in internal/config/config.go.
- Added managed-mode validation in internal/config/validate.go: requires admin.enabled, strong admin.session_secret, valid 32-byte base64 admin.totp_secret_key, and disables admin.debug.pprof.
- Added managed runtime visibility to doctor in internal/commands/doctor/doctor.go.
- Added managed runtime visibility to version metadata/output via FOUNDRY_MANAGED_RUNTIME, FOUNDRY_MANAGED_ENABLED, or FOUNDRY_CLOUD_MANAGED in internal/commands/version/metadata.go.
- Added parsing/validation/version tests.

## Why

Explain the motivation and context for the change.

## Testing

Describe how this was tested.

- [ ] `go test ./...`
- [ ] `go vet ./...`
- [ ] `go run ./cmd/plugin-sync`
- [ ] Manual testing performed
- [ ] Added or updated tests where appropriate

## Screenshots or output

Include screenshots, logs, or terminal output if relevant.

## Checklist

- [ ] I have read the contributing guidelines
- [ ] I have kept this PR focused in scope
- [ ] I have updated documentation if needed
- [ ] I have updated generated/plugin-related files if needed
- [ ] This change does not introduce known security issues