### PR TITLE
add managed-mode bootstrapper

### DIFF
--- a/internal/managed/bootstrap.go
+++ b/internal/managed/bootstrap.go
@@ -1,0 +1,189 @@
+package managed
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/mail"
+	"net/url"
+	"path"
+	"strings"
+	"time"
+)
+
+const (
+	BootstrapSignatureAlgorithm = "hmac-sha256"
+	minBootstrapSecretLength    = 32
+	minBootstrapNonceLength     = 16
+)
+
+type BootstrapPayload struct {
+	WorkspaceID        string         `json:"workspace_id"`
+	InstanceID         string         `json:"instance_id"`
+	OwnerEmail         string         `json:"owner_email"`
+	InitialSiteConfig  map[string]any `json:"initial_site_config"`
+	AdminPath          string         `json:"admin_path"`
+	RuntimeCallbackURL string         `json:"runtime_callback_url"`
+	IssuedAt           time.Time      `json:"issued_at"`
+	ExpiresAt          time.Time      `json:"expires_at"`
+	Nonce              string         `json:"nonce"`
+}
+
+type SignedBootstrapPayload struct {
+	Algorithm string           `json:"algorithm"`
+	Payload   BootstrapPayload `json:"payload"`
+	Signature string           `json:"signature"`
+}
+
+type BootstrapValidationOptions struct {
+	Now time.Time
+}
+
+func SignBootstrapPayload(payload BootstrapPayload, secret []byte) (SignedBootstrapPayload, error) {
+	if err := validateBootstrapSecret(secret); err != nil {
+		return SignedBootstrapPayload{}, err
+	}
+	if err := validateBootstrapPayloadFields(payload, time.Time{}); err != nil {
+		return SignedBootstrapPayload{}, err
+	}
+	signature, err := bootstrapSignature(payload, secret)
+	if err != nil {
+		return SignedBootstrapPayload{}, err
+	}
+	return SignedBootstrapPayload{
+		Algorithm: BootstrapSignatureAlgorithm,
+		Payload:   payload,
+		Signature: signature,
+	}, nil
+}
+
+func ValidateBootstrapPayload(signed SignedBootstrapPayload, secret []byte, opts BootstrapValidationOptions) (BootstrapPayload, error) {
+	if err := validateBootstrapSecret(secret); err != nil {
+		return BootstrapPayload{}, err
+	}
+	if strings.TrimSpace(signed.Algorithm) != BootstrapSignatureAlgorithm {
+		return BootstrapPayload{}, fmt.Errorf("unsupported bootstrap signature algorithm")
+	}
+	now := opts.Now
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	if err := validateBootstrapPayloadFields(signed.Payload, now); err != nil {
+		return BootstrapPayload{}, err
+	}
+	expected, err := bootstrapSignature(signed.Payload, secret)
+	if err != nil {
+		return BootstrapPayload{}, err
+	}
+	actual, err := hex.DecodeString(strings.TrimSpace(signed.Signature))
+	if err != nil {
+		return BootstrapPayload{}, fmt.Errorf("invalid bootstrap signature")
+	}
+	expectedBytes, err := hex.DecodeString(expected)
+	if err != nil {
+		return BootstrapPayload{}, fmt.Errorf("invalid bootstrap signature")
+	}
+	if !hmac.Equal(actual, expectedBytes) {
+		return BootstrapPayload{}, fmt.Errorf("invalid bootstrap signature")
+	}
+	return signed.Payload, nil
+}
+
+func validateBootstrapPayloadFields(payload BootstrapPayload, now time.Time) error {
+	if strings.TrimSpace(payload.WorkspaceID) == "" {
+		return fmt.Errorf("bootstrap payload missing workspace_id")
+	}
+	if strings.TrimSpace(payload.InstanceID) == "" {
+		return fmt.Errorf("bootstrap payload missing instance_id")
+	}
+	if strings.TrimSpace(payload.OwnerEmail) == "" {
+		return fmt.Errorf("bootstrap payload missing owner_email")
+	}
+	if _, err := mail.ParseAddress(strings.TrimSpace(payload.OwnerEmail)); err != nil {
+		return fmt.Errorf("bootstrap payload has invalid owner_email")
+	}
+	if len(payload.InitialSiteConfig) == 0 {
+		return fmt.Errorf("bootstrap payload missing initial_site_config")
+	}
+	if err := validateBootstrapAdminPath(payload.AdminPath); err != nil {
+		return err
+	}
+	if err := validateBootstrapCallbackURL(payload.RuntimeCallbackURL); err != nil {
+		return err
+	}
+	if payload.IssuedAt.IsZero() {
+		return fmt.Errorf("bootstrap payload missing issued_at")
+	}
+	if payload.ExpiresAt.IsZero() {
+		return fmt.Errorf("bootstrap payload missing expires_at")
+	}
+	if !payload.ExpiresAt.After(payload.IssuedAt) {
+		return fmt.Errorf("bootstrap payload expires_at must be after issued_at")
+	}
+	if strings.TrimSpace(payload.Nonce) == "" {
+		return fmt.Errorf("bootstrap payload missing nonce")
+	}
+	if len(strings.TrimSpace(payload.Nonce)) < minBootstrapNonceLength {
+		return fmt.Errorf("bootstrap payload nonce is too short")
+	}
+	if !now.IsZero() {
+		if payload.IssuedAt.After(now) {
+			return fmt.Errorf("bootstrap payload issued_at is in the future")
+		}
+		if !now.Before(payload.ExpiresAt) {
+			return fmt.Errorf("bootstrap payload has expired")
+		}
+	}
+	return nil
+}
+
+func validateBootstrapSecret(secret []byte) error {
+	if len(secret) < minBootstrapSecretLength {
+		return fmt.Errorf("bootstrap signing secret is too short")
+	}
+	return nil
+}
+
+func validateBootstrapAdminPath(value string) error {
+	value = strings.TrimSpace(strings.ReplaceAll(value, `\`, "/"))
+	if value == "" {
+		return fmt.Errorf("bootstrap payload missing admin_path")
+	}
+	if !strings.HasPrefix(value, "/") {
+		return fmt.Errorf("bootstrap payload admin_path must start with '/'")
+	}
+	clean := path.Clean(value)
+	if clean == "/" || clean != value {
+		return fmt.Errorf("bootstrap payload admin_path must be normalized and not root")
+	}
+	return nil
+}
+
+func validateBootstrapCallbackURL(value string) error {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return fmt.Errorf("bootstrap payload missing runtime_callback_url")
+	}
+	u, err := url.Parse(value)
+	if err != nil || u == nil || u.Host == "" {
+		return fmt.Errorf("bootstrap payload has invalid runtime_callback_url")
+	}
+	if u.Scheme != "https" && u.Scheme != "http" {
+		return fmt.Errorf("bootstrap payload runtime_callback_url must use http or https")
+	}
+	return nil
+}
+
+func bootstrapSignature(payload BootstrapPayload, secret []byte) (string, error) {
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return "", fmt.Errorf("marshal bootstrap payload: %w", err)
+	}
+	mac := hmac.New(sha256.New, secret)
+	if _, err := mac.Write(body); err != nil {
+		return "", fmt.Errorf("sign bootstrap payload: %w", err)
+	}
+	return hex.EncodeToString(mac.Sum(nil)), nil
+}

--- a/internal/managed/bootstrap_test.go
+++ b/internal/managed/bootstrap_test.go
@@ -1,0 +1,134 @@
+package managed
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestValidateBootstrapPayload(t *testing.T) {
+	secret := []byte(strings.Repeat("s", 32))
+	now := time.Date(2026, 4, 18, 12, 0, 0, 0, time.UTC)
+	payload := validBootstrapPayload(now)
+
+	signed, err := SignBootstrapPayload(payload, secret)
+	if err != nil {
+		t.Fatalf("sign payload: %v", err)
+	}
+	got, err := ValidateBootstrapPayload(signed, secret, BootstrapValidationOptions{Now: now})
+	if err != nil {
+		t.Fatalf("validate payload: %v", err)
+	}
+	if got.WorkspaceID != payload.WorkspaceID || got.InstanceID != payload.InstanceID {
+		t.Fatalf("unexpected validated payload: %#v", got)
+	}
+}
+
+func TestValidateBootstrapPayloadRejectsExpired(t *testing.T) {
+	secret := []byte(strings.Repeat("s", 32))
+	now := time.Date(2026, 4, 18, 12, 0, 0, 0, time.UTC)
+	payload := validBootstrapPayload(now)
+	payload.IssuedAt = now.Add(-2 * time.Hour)
+	payload.ExpiresAt = now.Add(-time.Hour)
+	signed, err := SignBootstrapPayload(payload, secret)
+	if err != nil {
+		t.Fatalf("sign payload: %v", err)
+	}
+	if _, err := ValidateBootstrapPayload(signed, secret, BootstrapValidationOptions{Now: now}); err == nil {
+		t.Fatal("expected expired payload to be rejected")
+	}
+}
+
+func TestValidateBootstrapPayloadRejectsFutureIssuedAt(t *testing.T) {
+	secret := []byte(strings.Repeat("s", 32))
+	now := time.Date(2026, 4, 18, 12, 0, 0, 0, time.UTC)
+	payload := validBootstrapPayload(now)
+	payload.IssuedAt = now.Add(time.Minute)
+	payload.ExpiresAt = now.Add(time.Hour)
+	signed, err := SignBootstrapPayload(payload, secret)
+	if err != nil {
+		t.Fatalf("sign payload: %v", err)
+	}
+	if _, err := ValidateBootstrapPayload(signed, secret, BootstrapValidationOptions{Now: now}); err == nil {
+		t.Fatal("expected future-issued payload to be rejected")
+	}
+}
+
+func TestValidateBootstrapPayloadRejectsTamperedPayload(t *testing.T) {
+	secret := []byte(strings.Repeat("s", 32))
+	now := time.Date(2026, 4, 18, 12, 0, 0, 0, time.UTC)
+	signed, err := SignBootstrapPayload(validBootstrapPayload(now), secret)
+	if err != nil {
+		t.Fatalf("sign payload: %v", err)
+	}
+	signed.Payload.OwnerEmail = "attacker@example.com"
+	if _, err := ValidateBootstrapPayload(signed, secret, BootstrapValidationOptions{Now: now}); err == nil {
+		t.Fatal("expected tampered payload to be rejected")
+	}
+}
+
+func TestValidateBootstrapPayloadRejectsMissingField(t *testing.T) {
+	secret := []byte(strings.Repeat("s", 32))
+	now := time.Date(2026, 4, 18, 12, 0, 0, 0, time.UTC)
+	payload := validBootstrapPayload(now)
+	payload.WorkspaceID = ""
+	signed := SignedBootstrapPayload{
+		Algorithm: BootstrapSignatureAlgorithm,
+		Payload:   payload,
+		Signature: strings.Repeat("0", 64),
+	}
+	if _, err := ValidateBootstrapPayload(signed, secret, BootstrapValidationOptions{Now: now}); err == nil {
+		t.Fatal("expected missing workspace_id to be rejected")
+	}
+}
+
+func TestValidateBootstrapPayloadRejectsBadSignature(t *testing.T) {
+	secret := []byte(strings.Repeat("s", 32))
+	now := time.Date(2026, 4, 18, 12, 0, 0, 0, time.UTC)
+	signed, err := SignBootstrapPayload(validBootstrapPayload(now), secret)
+	if err != nil {
+		t.Fatalf("sign payload: %v", err)
+	}
+	signed.Signature = strings.Repeat("f", 64)
+	if _, err := ValidateBootstrapPayload(signed, secret, BootstrapValidationOptions{Now: now}); err == nil {
+		t.Fatal("expected bad signature to be rejected")
+	}
+}
+
+func TestValidateBootstrapPayloadRejectsInvalidAdminPathAndCallbackURL(t *testing.T) {
+	secret := []byte(strings.Repeat("s", 32))
+	now := time.Date(2026, 4, 18, 12, 0, 0, 0, time.UTC)
+	for name, mutate := range map[string]func(*BootstrapPayload){
+		"root admin path":          func(p *BootstrapPayload) { p.AdminPath = "/" },
+		"unnormalized admin path":  func(p *BootstrapPayload) { p.AdminPath = "/admin/../admin" },
+		"missing callback host":    func(p *BootstrapPayload) { p.RuntimeCallbackURL = "https://" },
+		"unsupported callback URL": func(p *BootstrapPayload) { p.RuntimeCallbackURL = "file:///tmp/callback" },
+	} {
+		t.Run(name, func(t *testing.T) {
+			payload := validBootstrapPayload(now)
+			mutate(&payload)
+			signed := SignedBootstrapPayload{
+				Algorithm: BootstrapSignatureAlgorithm,
+				Payload:   payload,
+				Signature: strings.Repeat("0", 64),
+			}
+			if _, err := ValidateBootstrapPayload(signed, secret, BootstrapValidationOptions{Now: now}); err == nil {
+				t.Fatal("expected invalid payload to be rejected")
+			}
+		})
+	}
+}
+
+func validBootstrapPayload(now time.Time) BootstrapPayload {
+	return BootstrapPayload{
+		WorkspaceID:        "workspace-123",
+		InstanceID:         "instance-456",
+		OwnerEmail:         "owner@example.com",
+		InitialSiteConfig:  map[string]any{"title": "Managed Foundry", "base_url": "https://site.example.com"},
+		AdminPath:          "/__admin",
+		RuntimeCallbackURL: "https://control.example.com/runtime/callbacks",
+		IssuedAt:           now.Add(-time.Minute),
+		ExpiresAt:          now.Add(time.Hour),
+		Nonce:              "nonce-1234567890abcdef",
+	}
+}


### PR DESCRIPTION
## Summary

Added a new generic managed bootstrap package

## What changed

- Defines BootstrapPayload with workspace ID, instance ID, owner email, initial site config, admin path, runtime callback URL, issued/expires timestamps, and nonce.
- Defines SignedBootstrapPayload.
- Adds HMAC-SHA256 signing and validation.
- Rejects missing fields, expired payloads, future-issued payloads, tampered payloads, bad signatures, invalid admin paths, invalid callback URLs, short nonces, invalid email, and short signing secrets.
- Does not write files or apply bootstrap state.

## Why

Explain the motivation and context for the change.

## Testing

Describe how this was tested.

- [ ] `go test ./...`
- [ ] `go vet ./...`
- [ ] `go run ./cmd/plugin-sync`
- [ ] Manual testing performed
- [ ] Added or updated tests where appropriate

## Screenshots or output

Include screenshots, logs, or terminal output if relevant.

## Checklist

- [ ] I have read the contributing guidelines
- [ ] I have kept this PR focused in scope
- [ ] I have updated documentation if needed
- [ ] I have updated generated/plugin-related files if needed
- [ ] This change does not introduce known security issues