### PR TITLE
add durable bootstrap marker to bootstrap manager

### DIFF
--- a/internal/managed/bootstrap.go
+++ b/internal/managed/bootstrap.go
@@ -8,7 +8,9 @@ import (
 	"fmt"
 	"net/mail"
 	"net/url"
+	"os"
 	"path"
+	"path/filepath"
 	"strings"
 	"time"
 )
@@ -17,6 +19,9 @@ const (
 	BootstrapSignatureAlgorithm = "hmac-sha256"
 	minBootstrapSecretLength    = 32
 	minBootstrapNonceLength     = 16
+	bootstrapStateDir           = "managed"
+	bootstrapStateFile          = "bootstrap-state.json"
+	bootstrapLockFile           = "bootstrap-state.lock"
 )
 
 type BootstrapPayload struct {
@@ -39,6 +44,21 @@ type SignedBootstrapPayload struct {
 
 type BootstrapValidationOptions struct {
 	Now time.Time
+}
+
+type BootstrapState struct {
+	WorkspaceID   string    `json:"workspace_id"`
+	InstanceID    string    `json:"instance_id"`
+	CompletedAt   time.Time `json:"completed_at"`
+	Nonce         string    `json:"nonce"`
+	PayloadSHA256 string    `json:"payload_sha256"`
+}
+
+type BootstrapApplyOptions struct {
+	DataDir string
+	Payload BootstrapPayload
+	Now     time.Time
+	Apply   func(BootstrapPayload) error
 }
 
 func SignBootstrapPayload(payload BootstrapPayload, secret []byte) (SignedBootstrapPayload, error) {
@@ -89,6 +109,97 @@ func ValidateBootstrapPayload(signed SignedBootstrapPayload, secret []byte, opts
 		return BootstrapPayload{}, fmt.Errorf("invalid bootstrap signature")
 	}
 	return signed.Payload, nil
+}
+
+func ApplyBootstrapOnce(opts BootstrapApplyOptions) (BootstrapState, error) {
+	dataDir := strings.TrimSpace(opts.DataDir)
+	if dataDir == "" {
+		return BootstrapState{}, fmt.Errorf("bootstrap data directory is required")
+	}
+	if opts.Apply == nil {
+		return BootstrapState{}, fmt.Errorf("bootstrap apply function is required")
+	}
+	if err := validateBootstrapPayloadFields(opts.Payload, time.Time{}); err != nil {
+		return BootstrapState{}, err
+	}
+
+	statePath, lockPath, err := bootstrapStatePaths(dataDir)
+	if err != nil {
+		return BootstrapState{}, err
+	}
+	if existing, err := ReadBootstrapState(dataDir); err == nil {
+		return existing, fmt.Errorf("bootstrap has already completed")
+	} else if !os.IsNotExist(err) {
+		return BootstrapState{}, err
+	}
+
+	if err := os.MkdirAll(filepath.Dir(statePath), 0o700); err != nil {
+		return BootstrapState{}, fmt.Errorf("create bootstrap state directory: %w", err)
+	}
+	lock, err := os.OpenFile(lockPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		if os.IsExist(err) {
+			return BootstrapState{}, fmt.Errorf("bootstrap is already in progress")
+		}
+		return BootstrapState{}, fmt.Errorf("create bootstrap lock: %w", err)
+	}
+	_ = lock.Close()
+	defer func() {
+		_ = os.Remove(lockPath)
+	}()
+
+	if _, err := os.Stat(statePath); err == nil {
+		state, readErr := ReadBootstrapState(dataDir)
+		if readErr != nil {
+			return BootstrapState{}, readErr
+		}
+		return state, fmt.Errorf("bootstrap has already completed")
+	} else if !os.IsNotExist(err) {
+		return BootstrapState{}, fmt.Errorf("inspect bootstrap state: %w", err)
+	}
+
+	if err := opts.Apply(opts.Payload); err != nil {
+		return BootstrapState{}, fmt.Errorf("apply bootstrap payload: %w", err)
+	}
+
+	completedAt := opts.Now
+	if completedAt.IsZero() {
+		completedAt = time.Now().UTC()
+	}
+	hash, err := bootstrapPayloadHash(opts.Payload)
+	if err != nil {
+		return BootstrapState{}, err
+	}
+	state := BootstrapState{
+		WorkspaceID:   strings.TrimSpace(opts.Payload.WorkspaceID),
+		InstanceID:    strings.TrimSpace(opts.Payload.InstanceID),
+		CompletedAt:   completedAt.UTC(),
+		Nonce:         strings.TrimSpace(opts.Payload.Nonce),
+		PayloadSHA256: hash,
+	}
+	if err := writeBootstrapState(statePath, state); err != nil {
+		return BootstrapState{}, err
+	}
+	return state, nil
+}
+
+func ReadBootstrapState(dataDir string) (BootstrapState, error) {
+	statePath, _, err := bootstrapStatePaths(dataDir)
+	if err != nil {
+		return BootstrapState{}, err
+	}
+	b, err := os.ReadFile(statePath)
+	if err != nil {
+		return BootstrapState{}, err
+	}
+	var state BootstrapState
+	if err := json.Unmarshal(b, &state); err != nil {
+		return BootstrapState{}, fmt.Errorf("decode bootstrap state: %w", err)
+	}
+	if strings.TrimSpace(state.WorkspaceID) == "" || strings.TrimSpace(state.InstanceID) == "" || state.CompletedAt.IsZero() {
+		return BootstrapState{}, fmt.Errorf("bootstrap state is incomplete")
+	}
+	return state, nil
 }
 
 func validateBootstrapPayloadFields(payload BootstrapPayload, now time.Time) error {
@@ -186,4 +297,43 @@ func bootstrapSignature(payload BootstrapPayload, secret []byte) (string, error)
 		return "", fmt.Errorf("sign bootstrap payload: %w", err)
 	}
 	return hex.EncodeToString(mac.Sum(nil)), nil
+}
+
+func bootstrapPayloadHash(payload BootstrapPayload) (string, error) {
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return "", fmt.Errorf("marshal bootstrap payload: %w", err)
+	}
+	sum := sha256.Sum256(body)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+func bootstrapStatePaths(dataDir string) (string, string, error) {
+	dataDir = strings.TrimSpace(dataDir)
+	if dataDir == "" {
+		return "", "", fmt.Errorf("bootstrap data directory is required")
+	}
+	root, err := filepath.Abs(dataDir)
+	if err != nil {
+		return "", "", fmt.Errorf("resolve bootstrap data directory: %w", err)
+	}
+	stateDir := filepath.Join(root, bootstrapStateDir)
+	return filepath.Join(stateDir, bootstrapStateFile), filepath.Join(stateDir, bootstrapLockFile), nil
+}
+
+func writeBootstrapState(path string, state BootstrapState) error {
+	body, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal bootstrap state: %w", err)
+	}
+	body = append(body, '\n')
+	tmpPath := path + ".tmp"
+	if err := os.WriteFile(tmpPath, body, 0o600); err != nil {
+		return fmt.Errorf("write bootstrap state: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("commit bootstrap state: %w", err)
+	}
+	return nil
 }

--- a/internal/managed/bootstrap_test.go
+++ b/internal/managed/bootstrap_test.go
@@ -1,6 +1,9 @@
 package managed
 
 import (
+	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -116,6 +119,132 @@ func TestValidateBootstrapPayloadRejectsInvalidAdminPathAndCallbackURL(t *testin
 				t.Fatal("expected invalid payload to be rejected")
 			}
 		})
+	}
+}
+
+func TestApplyBootstrapOnceWritesStateAndRejectsReplay(t *testing.T) {
+	now := time.Date(2026, 4, 18, 12, 0, 0, 0, time.UTC)
+	dataDir := t.TempDir()
+	applied := 0
+
+	state, err := ApplyBootstrapOnce(BootstrapApplyOptions{
+		DataDir: dataDir,
+		Payload: validBootstrapPayload(now),
+		Now:     now,
+		Apply: func(payload BootstrapPayload) error {
+			applied++
+			if payload.WorkspaceID != "workspace-123" {
+				t.Fatalf("unexpected workspace ID passed to apply: %q", payload.WorkspaceID)
+			}
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("apply bootstrap: %v", err)
+	}
+	if applied != 1 {
+		t.Fatalf("expected apply callback once, got %d", applied)
+	}
+	if state.WorkspaceID != "workspace-123" || state.InstanceID != "instance-456" {
+		t.Fatalf("unexpected bootstrap state: %#v", state)
+	}
+	if state.CompletedAt != now {
+		t.Fatalf("expected completed_at %s, got %s", now, state.CompletedAt)
+	}
+	if state.Nonce == "" || state.PayloadSHA256 == "" {
+		t.Fatalf("expected nonce and payload hash in state: %#v", state)
+	}
+
+	read, err := ReadBootstrapState(dataDir)
+	if err != nil {
+		t.Fatalf("read bootstrap state: %v", err)
+	}
+	if read.PayloadSHA256 != state.PayloadSHA256 {
+		t.Fatalf("expected persisted hash %q, got %q", state.PayloadSHA256, read.PayloadSHA256)
+	}
+
+	_, err = ApplyBootstrapOnce(BootstrapApplyOptions{
+		DataDir: dataDir,
+		Payload: validBootstrapPayload(now.Add(time.Minute)),
+		Now:     now.Add(time.Minute),
+		Apply: func(BootstrapPayload) error {
+			applied++
+			return nil
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "already completed") {
+		t.Fatalf("expected replay rejection, got %v", err)
+	}
+	if applied != 1 {
+		t.Fatalf("expected replay not to call apply callback, got %d calls", applied)
+	}
+}
+
+func TestApplyBootstrapOnceFailedApplyLeavesNoCompletedMarker(t *testing.T) {
+	now := time.Date(2026, 4, 18, 12, 0, 0, 0, time.UTC)
+	dataDir := t.TempDir()
+	expectedErr := errors.New("write site config")
+
+	if _, err := ApplyBootstrapOnce(BootstrapApplyOptions{
+		DataDir: dataDir,
+		Payload: validBootstrapPayload(now),
+		Now:     now,
+		Apply: func(BootstrapPayload) error {
+			return expectedErr
+		},
+	}); !errors.Is(err, expectedErr) {
+		t.Fatalf("expected apply error %v, got %v", expectedErr, err)
+	}
+	if _, err := ReadBootstrapState(dataDir); !os.IsNotExist(err) {
+		t.Fatalf("expected no completed bootstrap state, got %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dataDir, bootstrapStateDir, bootstrapLockFile)); !os.IsNotExist(err) {
+		t.Fatalf("expected bootstrap lock cleanup, got %v", err)
+	}
+
+	applied := 0
+	if _, err := ApplyBootstrapOnce(BootstrapApplyOptions{
+		DataDir: dataDir,
+		Payload: validBootstrapPayload(now),
+		Now:     now,
+		Apply: func(BootstrapPayload) error {
+			applied++
+			return nil
+		},
+	}); err != nil {
+		t.Fatalf("expected retry after failed apply to succeed, got %v", err)
+	}
+	if applied != 1 {
+		t.Fatalf("expected retry apply callback once, got %d", applied)
+	}
+}
+
+func TestApplyBootstrapOnceRejectsInProgressBootstrap(t *testing.T) {
+	now := time.Date(2026, 4, 18, 12, 0, 0, 0, time.UTC)
+	dataDir := t.TempDir()
+	lockDir := filepath.Join(dataDir, bootstrapStateDir)
+	if err := os.MkdirAll(lockDir, 0o700); err != nil {
+		t.Fatalf("create lock dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(lockDir, bootstrapLockFile), []byte("locked"), 0o600); err != nil {
+		t.Fatalf("write lock: %v", err)
+	}
+
+	called := false
+	_, err := ApplyBootstrapOnce(BootstrapApplyOptions{
+		DataDir: dataDir,
+		Payload: validBootstrapPayload(now),
+		Now:     now,
+		Apply: func(BootstrapPayload) error {
+			called = true
+			return nil
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "already in progress") {
+		t.Fatalf("expected in-progress rejection, got %v", err)
+	}
+	if called {
+		t.Fatal("expected in-progress bootstrap not to call apply callback")
 	}
 }
 


### PR DESCRIPTION
## Summary

Describe the purpose of this change.

## What changed

- Added managed.ApplyBootstrapOnce in internal/managed/bootstrap.go, which writes a durable one-time bootstrap marker under data/managed/bootstrap-state.json.
- Stored bootstrap metadata: workspace_id, instance_id, completed_at, nonce, and payload_sha256.
- Added replay protection and an in-progress lock so a completed bootstrap cannot be applied again.
- Added temp-dir tests in internal/managed/bootstrap_test.go for first apply, replay rejection, failed apply cleanup, and in-progress rejection.

## Why

Explain the motivation and context for the change.

## Testing

Describe how this was tested.

- [ ] `go test ./...`
- [ ] `go vet ./...`
- [ ] `go run ./cmd/plugin-sync`
- [ ] Manual testing performed
- [ ] Added or updated tests where appropriate

## Screenshots or output

Include screenshots, logs, or terminal output if relevant.

## Checklist

- [ ] I have read the contributing guidelines
- [ ] I have kept this PR focused in scope
- [ ] I have updated documentation if needed
- [ ] I have updated generated/plugin-related files if needed
- [ ] This change does not introduce known security issues