### PR TITLE
add serv health and other managed backend goodies

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,6 +416,30 @@ The production compose shape is stricter:
 Before using the production Docker overlay, set the real HTTPS origin in
 `content/config/site.docker.prod.yaml`.
 
+#### Managed Runtime Storage Layout
+
+When `foundry.managed.enabled` is true, Foundry expects a provider-neutral
+runtime layout that also works with a read-only container root filesystem.
+The executable, built-in assets, and application code should be treated as
+immutable. Mutable runtime state must live in writable mounts or volumes:
+
+- `content_dir`: customer-authored Markdown, media references, and content metadata
+- `data_dir`: admin/runtime state, managed bootstrap state, sessions, locks, indexes, and other local state
+- `themes_dir`: installed or customized themes
+- `plugins_dir`: installed plugins
+- `public_dir`: generated public output
+- `/tmp`: ephemeral scratch space, usually `tmpfs`
+
+Foundry does not prescribe the backing provider for these paths. A managed
+operator can map them to local volumes, network filesystems, object-backed
+sync jobs, or another storage system. The important invariant is that the
+configured paths are readable and writable by the Foundry process while the
+container/application root remains read-only.
+
+`foundry doctor` and `GET /__health` both check the managed storage layout.
+The checks report only logical names such as `storage.data` and generic
+failure messages, not absolute filesystem paths or secret values.
+
 #### Source / local binary
 
 Start the local preview server from the project root:

--- a/internal/commands/doctor/doctor.go
+++ b/internal/commands/doctor/doctor.go
@@ -13,6 +13,7 @@ import (
 	"github.com/sphireinc/foundry/internal/commands/registry"
 	foundryconfig "github.com/sphireinc/foundry/internal/config"
 	"github.com/sphireinc/foundry/internal/content"
+	"github.com/sphireinc/foundry/internal/managed"
 	"github.com/sphireinc/foundry/internal/ops"
 	"github.com/sphireinc/foundry/internal/plugins"
 	"github.com/sphireinc/foundry/internal/renderer"
@@ -70,6 +71,9 @@ func (command) Run(cfg *foundryconfig.Config, _ []string) error {
 	}
 	if cfg.ManagedRuntimeEnabled() {
 		add("managed_runtime", true, "enabled")
+		for _, check := range managed.CheckStorageLayout(cfg) {
+			add("managed_"+check.Name, check.Status == managed.HealthCheckPass, check.Message)
+		}
 	} else {
 		add("managed_runtime", true, "disabled")
 	}

--- a/internal/commands/doctor/doctor_test.go
+++ b/internal/commands/doctor/doctor_test.go
@@ -98,6 +98,40 @@ func TestDoctorRunFailsOnLegacyAuthRecords(t *testing.T) {
 	}
 }
 
+func TestDoctorRunFailsManagedStorageCheck(t *testing.T) {
+	root := t.TempDir()
+	cfg := testProjectConfig(t, root)
+	cfg.Foundry.Managed.Enabled = true
+	cfg.Admin.Enabled = true
+	cfg.Admin.SessionSecret = strings.Repeat("a", 32)
+	cfg.Admin.TOTPSecretKey = "YmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmI="
+	cfg.PublicDir = filepath.Join(root, "missing-public")
+	if _, err := theme.Scaffold(cfg.ThemesDir, cfg.Theme); err != nil {
+		t.Fatalf("scaffold theme: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, "internal", "generated"), 0o755); err != nil {
+		t.Fatalf("mkdir generated: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "internal", "generated", "plugins_gen.go"), []byte("package generated\n"), 0o644); err != nil {
+		t.Fatalf("write generated imports: %v", err)
+	}
+
+	wd, _ := os.Getwd()
+	defer func() { _ = os.Chdir(wd) }()
+	if err := os.Chdir(root); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+
+	cmd := command{}
+	err := cmd.Run(cfg, nil)
+	if err == nil {
+		t.Fatal("expected doctor failure for missing managed public storage")
+	}
+	if !strings.Contains(err.Error(), "problem") {
+		t.Fatalf("unexpected doctor error: %v", err)
+	}
+}
+
 func testProjectConfig(t *testing.T, root string) *config.Config {
 	t.Helper()
 	cfg := &config.Config{

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -44,7 +44,10 @@ type FoundryConfig struct {
 }
 
 type ManagedRuntimeConfig struct {
-	Enabled bool `yaml:"enabled"`
+	Enabled      bool   `yaml:"enabled"`
+	InstanceID   string `yaml:"instance_id,omitempty"`
+	CallbackURL  string `yaml:"callback_url,omitempty"`
+	SharedSecret string `yaml:"shared_secret,omitempty"`
 }
 
 type AdminConfig struct {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -250,16 +250,43 @@ func TestManagedRuntimeConfigValidation(t *testing.T) {
 	if errs := Validate(cfg); len(errs) == 0 {
 		t.Fatal("expected managed runtime to reject short TOTP key")
 	}
+
+	cfg.Admin.TOTPSecretKey = base64.StdEncoding.EncodeToString([]byte(strings.Repeat("b", 32)))
+	cfg.Foundry.Managed.CallbackURL = "https://control.example.com/runtime/register"
+	cfg.Foundry.Managed.SharedSecret = strings.Repeat("s", 32)
+	if errs := Validate(cfg); len(errs) != 0 {
+		t.Fatalf("expected managed runtime callback config to validate, got %v", errs)
+	}
+
+	cfg.Foundry.Managed.CallbackURL = "file:///tmp/register"
+	if errs := Validate(cfg); len(errs) == 0 {
+		t.Fatal("expected managed runtime to reject invalid callback URL")
+	}
+
+	cfg.Foundry.Managed.CallbackURL = "https://control.example.com/runtime/register"
+	cfg.Foundry.Managed.SharedSecret = "short"
+	if errs := Validate(cfg); len(errs) == 0 {
+		t.Fatal("expected managed runtime to reject short callback shared secret")
+	}
 }
 
 func TestManagedRuntimeConfigParsesFromYAML(t *testing.T) {
-	body := []byte("theme: default\ndefault_lang: en\ncontent_dir: content\npublic_dir: public\nthemes_dir: themes\ndata_dir: data\nplugins_dir: plugins\nfoundry:\n  managed:\n    enabled: true\nadmin:\n  enabled: true\n  session_secret: " + strings.Repeat("a", 32) + "\n  totp_secret_key: " + base64.StdEncoding.EncodeToString([]byte(strings.Repeat("b", 32))) + "\nserver:\n  addr: :8080\nfeed:\n  rss_path: /rss.xml\n  sitemap_path: /sitemap.xml\n")
+	body := []byte("theme: default\ndefault_lang: en\ncontent_dir: content\npublic_dir: public\nthemes_dir: themes\ndata_dir: data\nplugins_dir: plugins\nfoundry:\n  managed:\n    enabled: true\n    instance_id: instance-123\n    callback_url: https://control.example.com/runtime/register\n    shared_secret: " + strings.Repeat("s", 32) + "\nadmin:\n  enabled: true\n  session_secret: " + strings.Repeat("a", 32) + "\n  totp_secret_key: " + base64.StdEncoding.EncodeToString([]byte(strings.Repeat("b", 32))) + "\nserver:\n  addr: :8080\nfeed:\n  rss_path: /rss.xml\n  sitemap_path: /sitemap.xml\n")
 	var cfg Config
 	if err := UnmarshalYAML(body, &cfg); err != nil {
 		t.Fatalf("unmarshal managed config: %v", err)
 	}
 	if !cfg.ManagedRuntimeEnabled() {
 		t.Fatal("expected managed runtime to be enabled from YAML")
+	}
+	if cfg.Foundry.Managed.InstanceID != "instance-123" {
+		t.Fatalf("expected managed instance ID from YAML, got %q", cfg.Foundry.Managed.InstanceID)
+	}
+	if cfg.Foundry.Managed.CallbackURL != "https://control.example.com/runtime/register" {
+		t.Fatalf("expected managed callback URL from YAML, got %q", cfg.Foundry.Managed.CallbackURL)
+	}
+	if cfg.Foundry.Managed.SharedSecret != strings.Repeat("s", 32) {
+		t.Fatal("expected managed shared secret from YAML")
 	}
 }
 

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -3,6 +3,7 @@ package config
 import (
 	"encoding/base64"
 	"fmt"
+	"net/url"
 	"path"
 	"regexp"
 	"strings"
@@ -197,7 +198,39 @@ func validateManagedRuntimeConfig(cfg *Config) []error {
 	if cfg.Admin.Debug.Pprof {
 		errs = append(errs, fmt.Errorf("foundry.managed.enabled requires admin.debug.pprof to be false"))
 	}
+	errs = append(errs, validateManagedRuntimeCallbackConfig(cfg.Foundry.Managed)...)
 	return errs
+}
+
+func validateManagedRuntimeCallbackConfig(managed ManagedRuntimeConfig) []error {
+	callbackURL := strings.TrimSpace(managed.CallbackURL)
+	sharedSecret := strings.TrimSpace(managed.SharedSecret)
+	if callbackURL == "" && sharedSecret == "" {
+		return nil
+	}
+	var errs []error
+	if callbackURL == "" {
+		errs = append(errs, fmt.Errorf("foundry.managed.callback_url is required when foundry.managed.shared_secret is set"))
+	} else if err := validateManagedCallbackURL(callbackURL); err != nil {
+		errs = append(errs, err)
+	}
+	if sharedSecret == "" {
+		errs = append(errs, fmt.Errorf("foundry.managed.shared_secret is required when foundry.managed.callback_url is set"))
+	} else if err := validateManagedSecret("foundry.managed.shared_secret", sharedSecret, false); err != nil {
+		errs = append(errs, err)
+	}
+	return errs
+}
+
+func validateManagedCallbackURL(value string) error {
+	u, err := url.Parse(strings.TrimSpace(value))
+	if err != nil || u == nil || u.Host == "" {
+		return fmt.Errorf("foundry.managed.callback_url must be a valid URL")
+	}
+	if u.Scheme != "https" && u.Scheme != "http" {
+		return fmt.Errorf("foundry.managed.callback_url must use http or https")
+	}
+	return nil
 }
 
 func validateManagedSecret(name, value string, requireBase64Key bool) error {

--- a/internal/managed/callback.go
+++ b/internal/managed/callback.go
@@ -1,0 +1,114 @@
+package managed
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+const defaultRuntimeMaxAttempts = 3
+
+type runtimeSignedCallbackOptions struct {
+	CallbackURL string
+	Secret      []byte
+	Event       string
+	Now         time.Time
+	Client      *http.Client
+	MaxAttempts int
+	RetryDelay  time.Duration
+	Payload     any
+}
+
+type runtimeSignedCallbackResult struct {
+	StatusCode int
+}
+
+func postSignedRuntimeCallback(ctx context.Context, opts runtimeSignedCallbackOptions) (runtimeSignedCallbackResult, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	callbackURL, err := validateRuntimeCallbackURL(opts.CallbackURL)
+	if err != nil {
+		return runtimeSignedCallbackResult{}, err
+	}
+	if err := validateBootstrapSecret(opts.Secret); err != nil {
+		return runtimeSignedCallbackResult{}, fmt.Errorf("runtime callback secret is too short")
+	}
+	now := opts.Now
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	body, err := json.Marshal(opts.Payload)
+	if err != nil {
+		return runtimeSignedCallbackResult{}, fmt.Errorf("marshal runtime callback payload: %w", err)
+	}
+	timestamp := now.UTC().Format(time.RFC3339)
+	signature := signRuntimeCallback(opts.Event, timestamp, body, opts.Secret)
+	client := opts.Client
+	if client == nil {
+		client = &http.Client{Timeout: defaultRuntimeHTTPTimeout}
+	}
+	attempts := opts.MaxAttempts
+	if attempts <= 0 {
+		attempts = defaultRuntimeMaxAttempts
+	}
+	retryDelay := opts.RetryDelay
+	if retryDelay <= 0 {
+		retryDelay = 100 * time.Millisecond
+	}
+
+	var lastStatus int
+	var lastErr error
+	for attempt := 1; attempt <= attempts; attempt++ {
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, callbackURL, bytes.NewReader(body))
+		if err != nil {
+			return runtimeSignedCallbackResult{}, fmt.Errorf("create runtime callback request: %w", err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Accept", "application/json")
+		req.Header.Set(RuntimeEventHeader, opts.Event)
+		req.Header.Set(RuntimeTimestampHeader, timestamp)
+		req.Header.Set(RuntimeSignatureHeader, runtimeSignaturePrefix+signature)
+
+		resp, err := client.Do(req)
+		if err != nil {
+			lastErr = err
+			if attempt < attempts && ctx.Err() == nil {
+				waitRuntimeRetry(ctx, retryDelay)
+				continue
+			}
+			return runtimeSignedCallbackResult{}, fmt.Errorf("post runtime callback: %w", err)
+		}
+		lastStatus = resp.StatusCode
+		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 1024))
+		_ = resp.Body.Close()
+		if resp.StatusCode >= 200 && resp.StatusCode <= 299 {
+			return runtimeSignedCallbackResult{StatusCode: resp.StatusCode}, nil
+		}
+		if !retryableRuntimeStatus(resp.StatusCode) || attempt == attempts {
+			return runtimeSignedCallbackResult{StatusCode: resp.StatusCode}, fmt.Errorf("runtime callback failed with status %d", resp.StatusCode)
+		}
+		waitRuntimeRetry(ctx, retryDelay)
+	}
+	if lastErr != nil {
+		return runtimeSignedCallbackResult{StatusCode: lastStatus}, fmt.Errorf("post runtime callback: %w", lastErr)
+	}
+	return runtimeSignedCallbackResult{StatusCode: lastStatus}, fmt.Errorf("runtime callback failed")
+}
+
+func retryableRuntimeStatus(status int) bool {
+	return status == http.StatusRequestTimeout || status == http.StatusTooManyRequests || status >= 500
+}
+
+func waitRuntimeRetry(ctx context.Context, delay time.Duration) {
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+	case <-timer.C:
+	}
+}

--- a/internal/managed/health.go
+++ b/internal/managed/health.go
@@ -1,0 +1,103 @@
+package managed
+
+import (
+	"strings"
+	"time"
+
+	"github.com/sphireinc/foundry/internal/config"
+)
+
+const (
+	HealthStatusHealthy  = "healthy"
+	HealthStatusDegraded = "degraded"
+	HealthCheckPass      = "pass"
+	HealthCheckFail      = "fail"
+)
+
+type HealthVersion struct {
+	Version string `json:"version"`
+	Commit  string `json:"commit"`
+}
+
+type HealthReport struct {
+	Status      string        `json:"status"`
+	Version     string        `json:"version"`
+	Commit      string        `json:"commit"`
+	Managed     bool          `json:"managed"`
+	InstanceID  string        `json:"instance_id,omitempty"`
+	AdminReady  bool          `json:"admin_ready"`
+	GeneratedAt time.Time     `json:"generated_at"`
+	Checks      []HealthCheck `json:"checks"`
+}
+
+type HealthCheck struct {
+	Name    string `json:"name"`
+	Status  string `json:"status"`
+	Message string `json:"message,omitempty"`
+}
+
+func BuildHealthReport(cfg *config.Config, version HealthVersion, now time.Time) HealthReport {
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	report := HealthReport{
+		Status:      HealthStatusHealthy,
+		Version:     strings.TrimSpace(version.Version),
+		Commit:      strings.TrimSpace(version.Commit),
+		Managed:     cfg != nil && cfg.ManagedRuntimeEnabled(),
+		AdminReady:  adminReady(cfg),
+		GeneratedAt: now.UTC(),
+	}
+	if report.Version == "" {
+		report.Version = "unknown"
+	}
+	if report.Commit == "" {
+		report.Commit = "unknown"
+	}
+	if cfg == nil {
+		report.addCheck("config", HealthCheckFail, "configuration is unavailable")
+		report.Status = HealthStatusDegraded
+		return report
+	}
+	report.InstanceID = managedInstanceID(cfg)
+	report.addBoolCheck("admin", report.AdminReady, "admin is ready", "admin is not ready")
+	for _, check := range CheckStorageLayout(cfg) {
+		report.addCheck(check.Name, check.Status, check.Message)
+	}
+	for _, check := range report.Checks {
+		if check.Status != HealthCheckPass {
+			report.Status = HealthStatusDegraded
+			break
+		}
+	}
+	return report
+}
+
+func (h *HealthReport) addBoolCheck(name string, ok bool, passMessage, failMessage string) {
+	if ok {
+		h.addCheck(name, HealthCheckPass, passMessage)
+		return
+	}
+	h.addCheck(name, HealthCheckFail, failMessage)
+}
+
+func (h *HealthReport) addCheck(name, status, message string) {
+	h.Checks = append(h.Checks, HealthCheck{Name: name, Status: status, Message: message})
+}
+
+func adminReady(cfg *config.Config) bool {
+	return cfg != nil && cfg.Admin.Enabled && strings.TrimSpace(cfg.AdminPath()) != ""
+}
+
+func managedInstanceID(cfg *config.Config) string {
+	if cfg == nil {
+		return ""
+	}
+	if id := strings.TrimSpace(cfg.Foundry.Managed.InstanceID); id != "" {
+		return id
+	}
+	if state, err := ReadBootstrapState(cfg.DataDir); err == nil {
+		return strings.TrimSpace(state.InstanceID)
+	}
+	return ""
+}

--- a/internal/managed/health_test.go
+++ b/internal/managed/health_test.go
@@ -1,0 +1,158 @@
+package managed
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sphireinc/foundry/internal/config"
+)
+
+func TestBuildHealthReportHealthy(t *testing.T) {
+	cfg := testHealthConfig(t)
+	cfg.Foundry.Managed.Enabled = true
+	cfg.Foundry.Managed.InstanceID = "instance-123"
+	cfg.Admin.Enabled = true
+	now := time.Date(2026, 4, 18, 12, 0, 0, 0, time.UTC)
+
+	report := BuildHealthReport(cfg, HealthVersion{Version: "v1.3.9", Commit: "abc1234"}, now)
+	if report.Status != HealthStatusHealthy {
+		t.Fatalf("expected healthy status, got %#v", report)
+	}
+	if !report.Managed {
+		t.Fatal("expected managed=true")
+	}
+	if report.InstanceID != "instance-123" {
+		t.Fatalf("expected configured instance ID, got %q", report.InstanceID)
+	}
+	if !report.AdminReady {
+		t.Fatal("expected admin ready")
+	}
+	if report.Version != "v1.3.9" || report.Commit != "abc1234" {
+		t.Fatalf("unexpected version metadata: %#v", report)
+	}
+	for _, check := range report.Checks {
+		if check.Status != HealthCheckPass {
+			t.Fatalf("expected all checks to pass, got %#v", report.Checks)
+		}
+		if strings.Contains(check.Message, string(filepath.Separator)) {
+			t.Fatalf("health message leaks filesystem detail: %#v", check)
+		}
+	}
+}
+
+func TestBuildHealthReportDegraded(t *testing.T) {
+	cfg := testHealthConfig(t)
+	cfg.Admin.Enabled = false
+	cfg.PublicDir = filepath.Join(t.TempDir(), "missing-public")
+
+	report := BuildHealthReport(cfg, HealthVersion{}, time.Date(2026, 4, 18, 12, 0, 0, 0, time.UTC))
+	if report.Status != HealthStatusDegraded {
+		t.Fatalf("expected degraded status, got %#v", report)
+	}
+	if report.Managed {
+		t.Fatal("expected managed=false")
+	}
+	if report.AdminReady {
+		t.Fatal("expected admin not ready")
+	}
+	if report.Version != "unknown" || report.Commit != "unknown" {
+		t.Fatalf("expected unknown version defaults, got %#v", report)
+	}
+	foundAdminFailure := false
+	foundStorageFailure := false
+	for _, check := range report.Checks {
+		if check.Name == "admin" && check.Status == HealthCheckFail {
+			foundAdminFailure = true
+		}
+		if check.Name == "storage.public" && check.Status == HealthCheckFail {
+			foundStorageFailure = true
+			if strings.Contains(check.Message, cfg.PublicDir) {
+				t.Fatalf("storage failure leaked directory path: %#v", check)
+			}
+		}
+	}
+	if !foundAdminFailure || !foundStorageFailure {
+		t.Fatalf("expected admin and public storage failures, got %#v", report.Checks)
+	}
+}
+
+func TestBuildHealthReportReadsBootstrapInstanceID(t *testing.T) {
+	cfg := testHealthConfig(t)
+	cfg.Admin.Enabled = true
+	now := time.Date(2026, 4, 18, 12, 0, 0, 0, time.UTC)
+	_, err := ApplyBootstrapOnce(BootstrapApplyOptions{
+		DataDir: cfg.DataDir,
+		Payload: validBootstrapPayload(now),
+		Now:     now,
+		Apply: func(BootstrapPayload) error {
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("apply bootstrap: %v", err)
+	}
+
+	report := BuildHealthReport(cfg, HealthVersion{}, now)
+	if report.InstanceID != "instance-456" {
+		t.Fatalf("expected bootstrap instance ID, got %q", report.InstanceID)
+	}
+}
+
+func TestCheckStorageLayoutReportsRequiredWritablePaths(t *testing.T) {
+	cfg := testHealthConfig(t)
+	checks := CheckStorageLayout(cfg)
+	if len(checks) != len(RuntimeStorageLayout()) {
+		t.Fatalf("expected one check per layout entry, got %#v", checks)
+	}
+	for _, check := range checks {
+		if check.Status != HealthCheckPass {
+			t.Fatalf("expected storage check to pass: %#v", check)
+		}
+	}
+
+	cfg.PublicDir = filepath.Join(t.TempDir(), "missing")
+	checks = CheckStorageLayout(cfg)
+	foundPublicFailure := false
+	for _, check := range checks {
+		if check.Name == "storage.public" {
+			foundPublicFailure = true
+			if check.Status != HealthCheckFail {
+				t.Fatalf("expected public storage failure, got %#v", check)
+			}
+			if strings.Contains(check.Message, cfg.PublicDir) {
+				t.Fatalf("storage layout check leaked path: %#v", check)
+			}
+		}
+	}
+	if !foundPublicFailure {
+		t.Fatalf("expected public storage check, got %#v", checks)
+	}
+}
+
+func testHealthConfig(t *testing.T) *config.Config {
+	t.Helper()
+	root := t.TempDir()
+	cfg := &config.Config{
+		Theme:       "default",
+		DefaultLang: "en",
+		ContentDir:  filepath.Join(root, "content"),
+		PublicDir:   filepath.Join(root, "public"),
+		ThemesDir:   filepath.Join(root, "themes"),
+		DataDir:     filepath.Join(root, "data"),
+		PluginsDir:  filepath.Join(root, "plugins"),
+		Admin: config.AdminConfig{
+			Enabled: true,
+			Path:    "/__admin",
+		},
+	}
+	cfg.ApplyDefaults()
+	for _, dir := range []string{cfg.ContentDir, cfg.PublicDir, cfg.ThemesDir, cfg.DataDir, cfg.PluginsDir} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+	return cfg
+}

--- a/internal/managed/registration.go
+++ b/internal/managed/registration.go
@@ -1,0 +1,150 @@
+package managed
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+const (
+	RuntimeRegistrationEvent  = "runtime.registration"
+	RuntimeSignatureHeader    = "X-Foundry-Signature"
+	RuntimeTimestampHeader    = "X-Foundry-Timestamp"
+	RuntimeEventHeader        = "X-Foundry-Event"
+	runtimeSignaturePrefix    = "hmac-sha256="
+	defaultRuntimeHTTPTimeout = 10 * time.Second
+)
+
+type RuntimeRegistrationPayload struct {
+	WorkspaceID          string    `json:"workspace_id"`
+	InstanceID           string    `json:"instance_id"`
+	Version              string    `json:"version"`
+	Commit               string    `json:"commit"`
+	SiteURL              string    `json:"site_url"`
+	AdminURL             string    `json:"admin_url"`
+	HealthStatus         string    `json:"health_status"`
+	BootstrapCompletedAt time.Time `json:"bootstrap_completed_at"`
+	RegisteredAt         time.Time `json:"registered_at"`
+}
+
+type RuntimeRegistrationOptions struct {
+	Managed     bool
+	CallbackURL string
+	Secret      []byte
+	Payload     RuntimeRegistrationPayload
+	Now         time.Time
+	Client      *http.Client
+	MaxAttempts int
+	RetryDelay  time.Duration
+}
+
+type RuntimeRegistrationResult struct {
+	Skipped    bool
+	StatusCode int
+}
+
+func RegisterRuntime(ctx context.Context, opts RuntimeRegistrationOptions) (RuntimeRegistrationResult, error) {
+	if !opts.Managed {
+		return RuntimeRegistrationResult{Skipped: true}, nil
+	}
+	now := opts.Now
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	payload := opts.Payload
+	payload.RegisteredAt = now.UTC()
+	if err := validateRuntimeRegistrationPayload(payload); err != nil {
+		return RuntimeRegistrationResult{}, err
+	}
+	result, err := postSignedRuntimeCallback(ctx, runtimeSignedCallbackOptions{
+		CallbackURL: opts.CallbackURL,
+		Secret:      opts.Secret,
+		Event:       RuntimeRegistrationEvent,
+		Now:         now,
+		Client:      opts.Client,
+		MaxAttempts: opts.MaxAttempts,
+		RetryDelay:  opts.RetryDelay,
+		Payload:     payload,
+	})
+	if err != nil {
+		return RuntimeRegistrationResult{StatusCode: result.StatusCode}, err
+	}
+	return RuntimeRegistrationResult{StatusCode: result.StatusCode}, nil
+}
+
+func validateRuntimeRegistrationPayload(payload RuntimeRegistrationPayload) error {
+	if strings.TrimSpace(payload.WorkspaceID) == "" {
+		return fmt.Errorf("runtime registration missing workspace_id")
+	}
+	if strings.TrimSpace(payload.InstanceID) == "" {
+		return fmt.Errorf("runtime registration missing instance_id")
+	}
+	if strings.TrimSpace(payload.Version) == "" {
+		return fmt.Errorf("runtime registration missing version")
+	}
+	if strings.TrimSpace(payload.Commit) == "" {
+		return fmt.Errorf("runtime registration missing commit")
+	}
+	if err := validateRuntimeURL("site_url", payload.SiteURL); err != nil {
+		return err
+	}
+	if err := validateRuntimeURL("admin_url", payload.AdminURL); err != nil {
+		return err
+	}
+	if strings.TrimSpace(payload.HealthStatus) == "" {
+		return fmt.Errorf("runtime registration missing health_status")
+	}
+	if payload.BootstrapCompletedAt.IsZero() {
+		return fmt.Errorf("runtime registration missing bootstrap_completed_at")
+	}
+	if payload.RegisteredAt.IsZero() {
+		return fmt.Errorf("runtime registration missing registered_at")
+	}
+	return nil
+}
+
+func validateRuntimeCallbackURL(value string) (string, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "", fmt.Errorf("runtime callback URL is required")
+	}
+	u, err := url.Parse(value)
+	if err != nil || u == nil || u.Host == "" {
+		return "", fmt.Errorf("runtime callback URL is invalid")
+	}
+	if u.Scheme != "https" && u.Scheme != "http" {
+		return "", fmt.Errorf("runtime callback URL must use http or https")
+	}
+	return u.String(), nil
+}
+
+func validateRuntimeURL(name, value string) error {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return fmt.Errorf("runtime registration missing %s", name)
+	}
+	u, err := url.Parse(value)
+	if err != nil || u == nil || u.Host == "" {
+		return fmt.Errorf("runtime registration has invalid %s", name)
+	}
+	if u.Scheme != "https" && u.Scheme != "http" {
+		return fmt.Errorf("runtime registration %s must use http or https", name)
+	}
+	return nil
+}
+
+func signRuntimeCallback(event, timestamp string, body, secret []byte) string {
+	mac := hmac.New(sha256.New, secret)
+	_, _ = mac.Write([]byte(strings.TrimSpace(timestamp)))
+	_, _ = mac.Write([]byte("."))
+	_, _ = mac.Write([]byte(strings.TrimSpace(event)))
+	_, _ = mac.Write([]byte("."))
+	_, _ = mac.Write(body)
+	return hex.EncodeToString(mac.Sum(nil))
+}

--- a/internal/managed/registration_test.go
+++ b/internal/managed/registration_test.go
@@ -1,0 +1,189 @@
+package managed
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestRegisterRuntimeSkipsOutsideManagedMode(t *testing.T) {
+	called := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	result, err := RegisterRuntime(context.Background(), RuntimeRegistrationOptions{
+		Managed:     false,
+		CallbackURL: server.URL,
+		Secret:      []byte(strings.Repeat("s", 32)),
+		Payload:     validRuntimeRegistrationPayload(time.Date(2026, 4, 18, 12, 0, 0, 0, time.UTC)),
+	})
+	if err != nil {
+		t.Fatalf("register runtime: %v", err)
+	}
+	if !result.Skipped {
+		t.Fatal("expected registration to be skipped")
+	}
+	if called {
+		t.Fatal("expected skipped registration not to call callback URL")
+	}
+}
+
+func TestRegisterRuntimePostsSignedRegistration(t *testing.T) {
+	now := time.Date(2026, 4, 18, 12, 0, 0, 0, time.UTC)
+	secret := []byte(strings.Repeat("s", 32))
+	var got RuntimeRegistrationPayload
+	var gotSignature string
+	var gotTimestamp string
+	var gotEvent string
+	var rawBody []byte
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("expected POST, got %s", r.Method)
+		}
+		if ct := r.Header.Get("Content-Type"); ct != "application/json" {
+			t.Fatalf("expected application/json content type, got %q", ct)
+		}
+		gotSignature = r.Header.Get(RuntimeSignatureHeader)
+		gotTimestamp = r.Header.Get(RuntimeTimestampHeader)
+		gotEvent = r.Header.Get(RuntimeEventHeader)
+		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		var err error
+		rawBody, err = json.Marshal(got)
+		if err != nil {
+			t.Fatalf("remarshal body: %v", err)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	result, err := RegisterRuntime(context.Background(), RuntimeRegistrationOptions{
+		Managed:     true,
+		CallbackURL: server.URL,
+		Secret:      secret,
+		Payload:     validRuntimeRegistrationPayload(now),
+		Now:         now,
+	})
+	if err != nil {
+		t.Fatalf("register runtime: %v", err)
+	}
+	if result.Skipped || result.StatusCode != http.StatusNoContent {
+		t.Fatalf("unexpected registration result: %#v", result)
+	}
+	if got.WorkspaceID != "workspace-123" || got.InstanceID != "instance-456" {
+		t.Fatalf("unexpected registration body: %#v", got)
+	}
+	if got.Version != "v1.3.9" || got.Commit != "abc1234" {
+		t.Fatalf("expected version and commit in body, got %#v", got)
+	}
+	if got.SiteURL != "https://site.example.com" || got.AdminURL != "https://site.example.com/__admin" {
+		t.Fatalf("expected site and admin URLs in body, got %#v", got)
+	}
+	if got.HealthStatus != "healthy" {
+		t.Fatalf("expected health status in body, got %#v", got)
+	}
+	if !got.BootstrapCompletedAt.Equal(now.Add(-time.Minute)) || !got.RegisteredAt.Equal(now) {
+		t.Fatalf("unexpected timestamps in body: %#v", got)
+	}
+	if gotEvent != RuntimeRegistrationEvent {
+		t.Fatalf("expected event header %q, got %q", RuntimeRegistrationEvent, gotEvent)
+	}
+	if gotTimestamp != now.Format(time.RFC3339) {
+		t.Fatalf("expected timestamp header %q, got %q", now.Format(time.RFC3339), gotTimestamp)
+	}
+	expectedSignature := runtimeSignaturePrefix + signRuntimeCallback(RuntimeRegistrationEvent, gotTimestamp, rawBody, secret)
+	if gotSignature != expectedSignature {
+		t.Fatalf("expected signature %q, got %q", expectedSignature, gotSignature)
+	}
+}
+
+func TestRegisterRuntimeRejectsNon2xx(t *testing.T) {
+	now := time.Date(2026, 4, 18, 12, 0, 0, 0, time.UTC)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "try later", http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+
+	result, err := RegisterRuntime(context.Background(), RuntimeRegistrationOptions{
+		Managed:     true,
+		CallbackURL: server.URL,
+		Secret:      []byte(strings.Repeat("s", 32)),
+		Payload:     validRuntimeRegistrationPayload(now),
+		Now:         now,
+	})
+	if err == nil || !strings.Contains(err.Error(), "status 503") {
+		t.Fatalf("expected non-2xx error, got %v", err)
+	}
+	if result.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("expected status 503 result, got %#v", result)
+	}
+}
+
+func TestRegisterRuntimeValidatesManagedInputs(t *testing.T) {
+	now := time.Date(2026, 4, 18, 12, 0, 0, 0, time.UTC)
+	for name, opts := range map[string]RuntimeRegistrationOptions{
+		"missing callback URL": {
+			Managed: true,
+			Secret:  []byte(strings.Repeat("s", 32)),
+			Payload: validRuntimeRegistrationPayload(now),
+			Now:     now,
+		},
+		"short secret": {
+			Managed:     true,
+			CallbackURL: "https://control.example.com/runtime/register",
+			Secret:      []byte("short"),
+			Payload:     validRuntimeRegistrationPayload(now),
+			Now:         now,
+		},
+		"missing instance": {
+			Managed:     true,
+			CallbackURL: "https://control.example.com/runtime/register",
+			Secret:      []byte(strings.Repeat("s", 32)),
+			Payload: func() RuntimeRegistrationPayload {
+				payload := validRuntimeRegistrationPayload(now)
+				payload.InstanceID = ""
+				return payload
+			}(),
+			Now: now,
+		},
+		"invalid admin URL": {
+			Managed:     true,
+			CallbackURL: "https://control.example.com/runtime/register",
+			Secret:      []byte(strings.Repeat("s", 32)),
+			Payload: func() RuntimeRegistrationPayload {
+				payload := validRuntimeRegistrationPayload(now)
+				payload.AdminURL = "file:///tmp/admin"
+				return payload
+			}(),
+			Now: now,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := RegisterRuntime(context.Background(), opts); err == nil {
+				t.Fatal("expected validation error")
+			}
+		})
+	}
+}
+
+func validRuntimeRegistrationPayload(now time.Time) RuntimeRegistrationPayload {
+	return RuntimeRegistrationPayload{
+		WorkspaceID:          "workspace-123",
+		InstanceID:           "instance-456",
+		Version:              "v1.3.9",
+		Commit:               "abc1234",
+		SiteURL:              "https://site.example.com",
+		AdminURL:             "https://site.example.com/__admin",
+		HealthStatus:         "healthy",
+		BootstrapCompletedAt: now.Add(-time.Minute),
+	}
+}

--- a/internal/managed/status.go
+++ b/internal/managed/status.go
@@ -1,0 +1,217 @@
+package managed
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+)
+
+const (
+	RuntimeDeploymentStatusEvent = "runtime.deployment.status"
+	RuntimeBackupStatusEvent     = "runtime.backup.status"
+	RuntimeRestoreStatusEvent    = "runtime.restore.status"
+	RuntimeDomainStatusEvent     = "runtime.domain.status"
+	RuntimeVersionStatusEvent    = "runtime.version.status"
+)
+
+type RuntimeStatusOptions struct {
+	Managed     bool
+	CallbackURL string
+	Secret      []byte
+	WorkspaceID string
+	InstanceID  string
+	Now         time.Time
+	Client      *http.Client
+	MaxAttempts int
+	RetryDelay  time.Duration
+}
+
+type RuntimeStatusCallbackPayload struct {
+	EventID     string         `json:"event_id"`
+	WorkspaceID string         `json:"workspace_id"`
+	InstanceID  string         `json:"instance_id"`
+	EventType   string         `json:"event_type"`
+	Status      string         `json:"status"`
+	Message     string         `json:"message,omitempty"`
+	ObservedAt  time.Time      `json:"observed_at"`
+	Metadata    map[string]any `json:"metadata,omitempty"`
+}
+
+type RuntimeStatusResult struct {
+	Skipped    bool
+	StatusCode int
+}
+
+type RuntimeDeploymentStatus struct {
+	Status       string
+	Message      string
+	DeploymentID string
+	Version      string
+	Commit       string
+	Metadata     map[string]any
+}
+
+type RuntimeBackupStatus struct {
+	Status       string
+	Message      string
+	BackupID     string
+	SnapshotName string
+	Metadata     map[string]any
+}
+
+type RuntimeRestoreStatus struct {
+	Status    string
+	Message   string
+	RestoreID string
+	BackupID  string
+	Metadata  map[string]any
+}
+
+type RuntimeDomainStatus struct {
+	Status    string
+	Message   string
+	Hostname  string
+	DNSStatus string
+	TLSStatus string
+	Metadata  map[string]any
+}
+
+type RuntimeVersionStatus struct {
+	Status         string
+	Message        string
+	CurrentVersion string
+	TargetVersion  string
+	UpdateID       string
+	Metadata       map[string]any
+}
+
+func SendDeploymentStatus(ctx context.Context, opts RuntimeStatusOptions, status RuntimeDeploymentStatus) (RuntimeStatusResult, error) {
+	metadata := copyRuntimeMetadata(status.Metadata)
+	setRuntimeMetadata(metadata, "deployment_id", status.DeploymentID)
+	setRuntimeMetadata(metadata, "version", status.Version)
+	setRuntimeMetadata(metadata, "commit", status.Commit)
+	return sendRuntimeStatus(ctx, opts, RuntimeDeploymentStatusEvent, status.Status, status.Message, metadata)
+}
+
+func SendBackupStatus(ctx context.Context, opts RuntimeStatusOptions, status RuntimeBackupStatus) (RuntimeStatusResult, error) {
+	metadata := copyRuntimeMetadata(status.Metadata)
+	setRuntimeMetadata(metadata, "backup_id", status.BackupID)
+	setRuntimeMetadata(metadata, "snapshot_name", status.SnapshotName)
+	return sendRuntimeStatus(ctx, opts, RuntimeBackupStatusEvent, status.Status, status.Message, metadata)
+}
+
+func SendRestoreStatus(ctx context.Context, opts RuntimeStatusOptions, status RuntimeRestoreStatus) (RuntimeStatusResult, error) {
+	metadata := copyRuntimeMetadata(status.Metadata)
+	setRuntimeMetadata(metadata, "restore_id", status.RestoreID)
+	setRuntimeMetadata(metadata, "backup_id", status.BackupID)
+	return sendRuntimeStatus(ctx, opts, RuntimeRestoreStatusEvent, status.Status, status.Message, metadata)
+}
+
+func SendDomainStatus(ctx context.Context, opts RuntimeStatusOptions, status RuntimeDomainStatus) (RuntimeStatusResult, error) {
+	metadata := copyRuntimeMetadata(status.Metadata)
+	setRuntimeMetadata(metadata, "hostname", status.Hostname)
+	setRuntimeMetadata(metadata, "dns_status", status.DNSStatus)
+	setRuntimeMetadata(metadata, "tls_status", status.TLSStatus)
+	return sendRuntimeStatus(ctx, opts, RuntimeDomainStatusEvent, status.Status, status.Message, metadata)
+}
+
+func SendVersionStatus(ctx context.Context, opts RuntimeStatusOptions, status RuntimeVersionStatus) (RuntimeStatusResult, error) {
+	metadata := copyRuntimeMetadata(status.Metadata)
+	setRuntimeMetadata(metadata, "current_version", status.CurrentVersion)
+	setRuntimeMetadata(metadata, "target_version", status.TargetVersion)
+	setRuntimeMetadata(metadata, "update_id", status.UpdateID)
+	return sendRuntimeStatus(ctx, opts, RuntimeVersionStatusEvent, status.Status, status.Message, metadata)
+}
+
+func sendRuntimeStatus(ctx context.Context, opts RuntimeStatusOptions, eventType, status, message string, metadata map[string]any) (RuntimeStatusResult, error) {
+	if !opts.Managed {
+		return RuntimeStatusResult{Skipped: true}, nil
+	}
+	now := opts.Now
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	payload := RuntimeStatusCallbackPayload{
+		WorkspaceID: strings.TrimSpace(opts.WorkspaceID),
+		InstanceID:  strings.TrimSpace(opts.InstanceID),
+		EventType:   strings.TrimSpace(eventType),
+		Status:      strings.TrimSpace(status),
+		Message:     strings.TrimSpace(message),
+		ObservedAt:  now.UTC(),
+		Metadata:    metadata,
+	}
+	if err := validateRuntimeStatusPayload(payload); err != nil {
+		return RuntimeStatusResult{}, err
+	}
+	eventID, err := runtimeStatusEventID(payload)
+	if err != nil {
+		return RuntimeStatusResult{}, err
+	}
+	payload.EventID = eventID
+	result, err := postSignedRuntimeCallback(ctx, runtimeSignedCallbackOptions{
+		CallbackURL: opts.CallbackURL,
+		Secret:      opts.Secret,
+		Event:       payload.EventType,
+		Now:         now,
+		Client:      opts.Client,
+		MaxAttempts: opts.MaxAttempts,
+		RetryDelay:  opts.RetryDelay,
+		Payload:     payload,
+	})
+	if err != nil {
+		return RuntimeStatusResult{StatusCode: result.StatusCode}, err
+	}
+	return RuntimeStatusResult{StatusCode: result.StatusCode}, nil
+}
+
+func validateRuntimeStatusPayload(payload RuntimeStatusCallbackPayload) error {
+	if strings.TrimSpace(payload.WorkspaceID) == "" {
+		return fmt.Errorf("runtime status missing workspace_id")
+	}
+	if strings.TrimSpace(payload.InstanceID) == "" {
+		return fmt.Errorf("runtime status missing instance_id")
+	}
+	if strings.TrimSpace(payload.EventType) == "" {
+		return fmt.Errorf("runtime status missing event_type")
+	}
+	if strings.TrimSpace(payload.Status) == "" {
+		return fmt.Errorf("runtime status missing status")
+	}
+	if payload.ObservedAt.IsZero() {
+		return fmt.Errorf("runtime status missing observed_at")
+	}
+	return nil
+}
+
+func runtimeStatusEventID(payload RuntimeStatusCallbackPayload) (string, error) {
+	payload.EventID = ""
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return "", fmt.Errorf("marshal runtime status event id: %w", err)
+	}
+	sum := sha256.Sum256(body)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+func copyRuntimeMetadata(in map[string]any) map[string]any {
+	out := make(map[string]any, len(in)+4)
+	for k, v := range in {
+		if strings.TrimSpace(k) == "" {
+			continue
+		}
+		out[k] = v
+	}
+	return out
+}
+
+func setRuntimeMetadata(metadata map[string]any, key, value string) {
+	if strings.TrimSpace(value) == "" {
+		return
+	}
+	metadata[key] = strings.TrimSpace(value)
+}

--- a/internal/managed/status_test.go
+++ b/internal/managed/status_test.go
@@ -1,0 +1,260 @@
+package managed
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestRuntimeStatusCallbacksPostSignedPayloads(t *testing.T) {
+	now := time.Date(2026, 4, 18, 12, 0, 0, 0, time.UTC)
+	secret := []byte(strings.Repeat("s", 32))
+
+	tests := []struct {
+		name     string
+		event    string
+		send     func(RuntimeStatusOptions) (RuntimeStatusResult, error)
+		metadata map[string]string
+	}{
+		{
+			name:  "deployment",
+			event: RuntimeDeploymentStatusEvent,
+			send: func(opts RuntimeStatusOptions) (RuntimeStatusResult, error) {
+				return SendDeploymentStatus(context.Background(), opts, RuntimeDeploymentStatus{
+					Status:       "succeeded",
+					Message:      "deployment completed",
+					DeploymentID: "deployment-123",
+					Version:      "v1.3.9",
+					Commit:       "abc1234",
+					Metadata:     map[string]any{"duration_ms": 1200},
+				})
+			},
+			metadata: map[string]string{
+				"deployment_id": "deployment-123",
+				"version":       "v1.3.9",
+				"commit":        "abc1234",
+			},
+		},
+		{
+			name:  "backup",
+			event: RuntimeBackupStatusEvent,
+			send: func(opts RuntimeStatusOptions) (RuntimeStatusResult, error) {
+				return SendBackupStatus(context.Background(), opts, RuntimeBackupStatus{
+					Status:       "succeeded",
+					Message:      "backup completed",
+					BackupID:     "backup-123",
+					SnapshotName: "snapshot.zip",
+				})
+			},
+			metadata: map[string]string{
+				"backup_id":     "backup-123",
+				"snapshot_name": "snapshot.zip",
+			},
+		},
+		{
+			name:  "restore",
+			event: RuntimeRestoreStatusEvent,
+			send: func(opts RuntimeStatusOptions) (RuntimeStatusResult, error) {
+				return SendRestoreStatus(context.Background(), opts, RuntimeRestoreStatus{
+					Status:    "running",
+					Message:   "restore started",
+					RestoreID: "restore-123",
+					BackupID:  "backup-123",
+				})
+			},
+			metadata: map[string]string{
+				"restore_id": "restore-123",
+				"backup_id":  "backup-123",
+			},
+		},
+		{
+			name:  "domain",
+			event: RuntimeDomainStatusEvent,
+			send: func(opts RuntimeStatusOptions) (RuntimeStatusResult, error) {
+				return SendDomainStatus(context.Background(), opts, RuntimeDomainStatus{
+					Status:    "ready",
+					Message:   "domain verified",
+					Hostname:  "site.example.com",
+					DNSStatus: "verified",
+					TLSStatus: "active",
+				})
+			},
+			metadata: map[string]string{
+				"hostname":   "site.example.com",
+				"dns_status": "verified",
+				"tls_status": "active",
+			},
+		},
+		{
+			name:  "version",
+			event: RuntimeVersionStatusEvent,
+			send: func(opts RuntimeStatusOptions) (RuntimeStatusResult, error) {
+				return SendVersionStatus(context.Background(), opts, RuntimeVersionStatus{
+					Status:         "available",
+					Message:        "update available",
+					CurrentVersion: "v1.3.9",
+					TargetVersion:  "v1.4.0",
+					UpdateID:       "update-123",
+				})
+			},
+			metadata: map[string]string{
+				"current_version": "v1.3.9",
+				"target_version":  "v1.4.0",
+				"update_id":       "update-123",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var payload RuntimeStatusCallbackPayload
+			var gotSignature string
+			var gotTimestamp string
+			var gotEvent string
+			var rawBody []byte
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotSignature = r.Header.Get(RuntimeSignatureHeader)
+				gotTimestamp = r.Header.Get(RuntimeTimestampHeader)
+				gotEvent = r.Header.Get(RuntimeEventHeader)
+				if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+					t.Fatalf("decode payload: %v", err)
+				}
+				var err error
+				rawBody, err = json.Marshal(payload)
+				if err != nil {
+					t.Fatalf("remarshal payload: %v", err)
+				}
+				w.WriteHeader(http.StatusNoContent)
+			}))
+			defer server.Close()
+
+			result, err := tt.send(RuntimeStatusOptions{
+				Managed:     true,
+				CallbackURL: server.URL,
+				Secret:      secret,
+				WorkspaceID: "workspace-123",
+				InstanceID:  "instance-456",
+				Now:         now,
+				MaxAttempts: 1,
+			})
+			if err != nil {
+				t.Fatalf("send status: %v", err)
+			}
+			if result.Skipped || result.StatusCode != http.StatusNoContent {
+				t.Fatalf("unexpected result: %#v", result)
+			}
+			if payload.EventID == "" {
+				t.Fatal("expected event_id")
+			}
+			if payload.WorkspaceID != "workspace-123" || payload.InstanceID != "instance-456" {
+				t.Fatalf("unexpected runtime IDs: %#v", payload)
+			}
+			if payload.EventType != tt.event || gotEvent != tt.event {
+				t.Fatalf("expected event %q, got body=%q header=%q", tt.event, payload.EventType, gotEvent)
+			}
+			if payload.Status == "" || payload.Message == "" {
+				t.Fatalf("expected status and message, got %#v", payload)
+			}
+			if !payload.ObservedAt.Equal(now) {
+				t.Fatalf("expected observed_at %s, got %s", now, payload.ObservedAt)
+			}
+			for key, want := range tt.metadata {
+				if got, _ := payload.Metadata[key].(string); got != want {
+					t.Fatalf("expected metadata %s=%q, got %#v", key, want, payload.Metadata[key])
+				}
+			}
+			if gotTimestamp != now.Format(time.RFC3339) {
+				t.Fatalf("expected timestamp %q, got %q", now.Format(time.RFC3339), gotTimestamp)
+			}
+			expectedSignature := runtimeSignaturePrefix + signRuntimeCallback(tt.event, gotTimestamp, rawBody, secret)
+			if gotSignature != expectedSignature {
+				t.Fatalf("expected signature %q, got %q", expectedSignature, gotSignature)
+			}
+		})
+	}
+}
+
+func TestRuntimeStatusSkipsOutsideManagedMode(t *testing.T) {
+	called := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	result, err := SendBackupStatus(context.Background(), RuntimeStatusOptions{
+		Managed:     false,
+		CallbackURL: server.URL,
+		Secret:      []byte(strings.Repeat("s", 32)),
+		WorkspaceID: "workspace-123",
+		InstanceID:  "instance-456",
+	}, RuntimeBackupStatus{Status: "succeeded", BackupID: "backup-123"})
+	if err != nil {
+		t.Fatalf("send skipped status: %v", err)
+	}
+	if !result.Skipped {
+		t.Fatal("expected skipped result")
+	}
+	if called {
+		t.Fatal("expected skipped status not to call callback URL")
+	}
+}
+
+func TestRuntimeStatusRetriesRetryableFailures(t *testing.T) {
+	now := time.Date(2026, 4, 18, 12, 0, 0, 0, time.UTC)
+	secret := []byte(strings.Repeat("s", 32))
+	attempts := 0
+	var firstEventID string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		var payload RuntimeStatusCallbackPayload
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode payload: %v", err)
+		}
+		if firstEventID == "" {
+			firstEventID = payload.EventID
+		} else if payload.EventID != firstEventID {
+			t.Fatalf("expected stable event ID across retries, got %q then %q", firstEventID, payload.EventID)
+		}
+		if attempts == 1 {
+			http.Error(w, "try again", http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	result, err := SendDeploymentStatus(context.Background(), RuntimeStatusOptions{
+		Managed:     true,
+		CallbackURL: server.URL,
+		Secret:      secret,
+		WorkspaceID: "workspace-123",
+		InstanceID:  "instance-456",
+		Now:         now,
+		MaxAttempts: 2,
+		RetryDelay:  time.Nanosecond,
+	}, RuntimeDeploymentStatus{Status: "succeeded", DeploymentID: "deployment-123"})
+	if err != nil {
+		t.Fatalf("expected retry to succeed, got %v", err)
+	}
+	if result.StatusCode != http.StatusNoContent || attempts != 2 {
+		t.Fatalf("expected second attempt success, result=%#v attempts=%d", result, attempts)
+	}
+}
+
+func TestRuntimeStatusRejectsInvalidPayload(t *testing.T) {
+	_, err := SendDomainStatus(context.Background(), RuntimeStatusOptions{
+		Managed:     true,
+		CallbackURL: "https://control.example.com/runtime/status",
+		Secret:      []byte(strings.Repeat("s", 32)),
+		WorkspaceID: "workspace-123",
+		InstanceID:  "instance-456",
+	}, RuntimeDomainStatus{Hostname: "site.example.com"})
+	if err == nil || !strings.Contains(err.Error(), "missing status") {
+		t.Fatalf("expected missing status validation error, got %v", err)
+	}
+}

--- a/internal/managed/storage.go
+++ b/internal/managed/storage.go
@@ -1,0 +1,89 @@
+package managed
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/sphireinc/foundry/internal/config"
+)
+
+type StorageLayoutEntry struct {
+	Name      string `json:"name"`
+	ConfigKey string `json:"config_key"`
+	Writable  bool   `json:"writable"`
+}
+
+type StorageLayoutCheck struct {
+	Name    string
+	Status  string
+	Message string
+}
+
+func RuntimeStorageLayout() []StorageLayoutEntry {
+	return []StorageLayoutEntry{
+		{Name: "content", ConfigKey: "content_dir", Writable: true},
+		{Name: "data", ConfigKey: "data_dir", Writable: true},
+		{Name: "public", ConfigKey: "public_dir", Writable: true},
+		{Name: "themes", ConfigKey: "themes_dir", Writable: true},
+		{Name: "plugins", ConfigKey: "plugins_dir", Writable: true},
+	}
+}
+
+func CheckStorageLayout(cfg *config.Config) []StorageLayoutCheck {
+	if cfg == nil {
+		return []StorageLayoutCheck{{Name: "storage.config", Status: HealthCheckFail, Message: "configuration is unavailable"}}
+	}
+	targets := map[string]string{
+		"content": cfg.ContentDir,
+		"data":    cfg.DataDir,
+		"public":  cfg.PublicDir,
+		"themes":  cfg.ThemesDir,
+		"plugins": cfg.PluginsDir,
+	}
+	checks := make([]StorageLayoutCheck, 0, len(targets))
+	for _, entry := range RuntimeStorageLayout() {
+		name := "storage." + entry.Name
+		if err := checkStorageReadWrite(targets[entry.Name]); err != nil {
+			checks = append(checks, StorageLayoutCheck{Name: name, Status: HealthCheckFail, Message: err.Error()})
+			continue
+		}
+		checks = append(checks, StorageLayoutCheck{Name: name, Status: HealthCheckPass, Message: "readable and writable"})
+	}
+	return checks
+}
+
+func checkStorageReadWrite(dir string) error {
+	dir = strings.TrimSpace(dir)
+	if dir == "" {
+		return fmt.Errorf("directory is not configured")
+	}
+	info, err := os.Stat(dir)
+	if err != nil {
+		return fmt.Errorf("directory is not available")
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("target is not a directory")
+	}
+	if _, err := os.ReadDir(dir); err != nil {
+		return fmt.Errorf("directory is not readable")
+	}
+	tmp, err := os.CreateTemp(dir, ".foundry-health-*")
+	if err != nil {
+		return fmt.Errorf("directory is not writable")
+	}
+	tmpName := tmp.Name()
+	if _, err := tmp.Write([]byte("ok")); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpName)
+		return fmt.Errorf("directory is not writable")
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpName)
+		return fmt.Errorf("directory is not writable")
+	}
+	if err := os.Remove(tmpName); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("temporary health file cleanup failed")
+	}
+	return nil
+}

--- a/internal/server/health.go
+++ b/internal/server/health.go
@@ -1,0 +1,38 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"time"
+
+	foundryversion "github.com/sphireinc/foundry/internal/commands/version"
+	"github.com/sphireinc/foundry/internal/managed"
+)
+
+func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet && r.Method != http.MethodHead {
+		w.Header().Set("Allow", http.MethodGet+", "+http.MethodHead)
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	meta := foundryversion.Current("")
+	report := managed.BuildHealthReport(s.cfg, managed.HealthVersion{
+		Version: meta.DisplayVersion,
+		Commit:  meta.Commit,
+	}, timeNow())
+	statusCode := http.StatusOK
+	if report.Status != managed.HealthStatusHealthy {
+		statusCode = http.StatusServiceUnavailable
+	}
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.Header().Set("Cache-Control", "no-store")
+	w.WriteHeader(statusCode)
+	if r.Method == http.MethodHead {
+		return
+	}
+	_ = json.NewEncoder(w).Encode(report)
+}
+
+var timeNow = func() time.Time {
+	return time.Now().UTC()
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -190,6 +190,7 @@ func (s *Server) newMux() *http.ServeMux {
 	if s.cfg.Server.DebugRoutes {
 		mux.HandleFunc("/__debug/deps", s.handleDepsDebug)
 	}
+	mux.HandleFunc("/__health", s.handleHealth)
 
 	mux.HandleFunc(s.cfg.Feed.RSSPath, s.handleRSS)
 	mux.HandleFunc(s.cfg.Feed.SitemapPath, s.handleSitemap)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -167,6 +167,68 @@ func TestServerHelpersAndHandlers(t *testing.T) {
 	}
 }
 
+func TestManagedHealthEndpointHealthyAndDoesNotBreakRoutes(t *testing.T) {
+	cfg := testServerConfig(t)
+	cfg.Admin.Enabled = true
+	cfg.Foundry.Managed.Enabled = true
+	cfg.Foundry.Managed.InstanceID = "instance-123"
+	for _, dir := range []string{cfg.ContentDir, cfg.PublicDir, cfg.ThemesDir, cfg.DataDir, cfg.PluginsDir} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+	oldTimeNow := timeNow
+	timeNow = func() time.Time {
+		return time.Date(2026, 4, 18, 12, 0, 0, 0, time.UTC)
+	}
+	t.Cleanup(func() { timeNow = oldTimeNow })
+
+	s := New(cfg, stubLoader{}, router.NewResolver(cfg), renderer.New(cfg, theme.NewManager(cfg.ThemesDir, cfg.Theme), nil), &hookRecorder{}, false)
+	mux := s.newMux()
+
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/__health", nil))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected healthy status code, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(rr.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("decode health response: %v", err)
+	}
+	if payload["status"] != "healthy" || payload["managed"] != true || payload["instance_id"] != "instance-123" {
+		t.Fatalf("unexpected health payload: %#v", payload)
+	}
+	if strings.Contains(rr.Body.String(), cfg.DataDir) {
+		t.Fatalf("health response leaked filesystem path: %s", rr.Body.String())
+	}
+
+	rr = httptest.NewRecorder()
+	mux.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/hook", nil))
+	if rr.Code != http.StatusOK || rr.Body.String() != "hook" {
+		t.Fatalf("expected existing hook route to keep working, got %d %q", rr.Code, rr.Body.String())
+	}
+}
+
+func TestManagedHealthEndpointDegraded(t *testing.T) {
+	cfg := testServerConfig(t)
+	cfg.Admin.Enabled = false
+	for _, dir := range []string{cfg.ContentDir, cfg.ThemesDir, cfg.DataDir, cfg.PluginsDir} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+	s := New(cfg, stubLoader{}, router.NewResolver(cfg), renderer.New(cfg, theme.NewManager(cfg.ThemesDir, cfg.Theme), nil), &hookRecorder{}, false)
+
+	rr := httptest.NewRecorder()
+	s.newMux().ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/__health", nil))
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected degraded status code, got %d: %s", rr.Code, rr.Body.String())
+	}
+	if strings.Contains(rr.Body.String(), cfg.PublicDir) {
+		t.Fatalf("health response leaked filesystem path: %s", rr.Body.String())
+	}
+}
+
 func TestServerChangeClassificationAndWatchHelpers(t *testing.T) {
 	cfg := testServerConfig(t)
 	s := &Server{cfg: cfg}


### PR DESCRIPTION
## Summary

Add serv health and other managed backend goodies

## What changed

- Added a generic signed runtime registration client in internal/managed/registration.go.
- Registration payload includes workspace ID, instance ID, version, commit, site URL, admin URL, health status, bootstrap completion time, and registration time.
- Requests use provider-neutral Foundry headers: X-Foundry-Event, X-Foundry-Timestamp, and X-Foundry-Signature.
- Registration skips cleanly when Managed is false and reports non-2xx callback responses as errors.
- Added optional managed config fields: foundry.managed.callback_url and foundry.managed.shared_secret, with validation only when configured.
- Added httptest coverage in internal/managed/registration_test.go.
- Added shared signed callback transport in internal/managed/callback.go with timeout, bounded retry for network/408/429/5xx failures, and no secret logging.
- Refactored runtime registration to use the shared callback transport in internal/managed/registration.go.
- Added reusable provider-neutral status callbacks in internal/managed/status.go for deployment, backup, restore, domain/TLS, and version/update events.
- Status callbacks include stable event IDs, event type, status, metadata, workspace ID, instance ID, and timestamp.
- Added httptest coverage in internal/managed/status_test.go verifying payload shapes, event headers, metadata, signatures, skipped non-managed mode, and retry behavior.
- Added a provider-neutral health report builder in internal/managed/health.go.
- Added GET/HEAD /__health in internal/server/health.go.
- Health response includes status, version, commit, managed mode, optional instance ID, admin readiness, generated timestamp, and storage checks.
- Storage checks verify read/write access for content, data, public, themes, and plugins without returning absolute filesystem paths.
- Added optional foundry.managed.instance_id config support.
- Added healthy/degraded tests in internal/managed/health_test.go and endpoint route tests in internal/server/server_test.go.
- Added provider-neutral storage layout helpers in internal/managed/storage.go.
- managed.RuntimeStorageLayout() documents required writable paths: content_dir, data_dir, public_dir, themes_dir, and plugins_dir.
- managed.CheckStorageLayout(cfg) verifies each path exists, is a directory, is readable, and is writable without leaking absolute paths.
- Wired managed storage checks into GET /__health via internal/managed/health.go.
- Wired managed storage checks into foundry doctor when foundry.managed.enabled is true in internal/commands/doctor/doctor.go.

## Why

Explain the motivation and context for the change.

## Testing

Describe how this was tested.

- [ ] `go test ./...`
- [ ] `go vet ./...`
- [ ] `go run ./cmd/plugin-sync`
- [ ] Manual testing performed
- [ ] Added or updated tests where appropriate

## Screenshots or output

Include screenshots, logs, or terminal output if relevant.

## Checklist

- [ ] I have read the contributing guidelines
- [ ] I have kept this PR focused in scope
- [ ] I have updated documentation if needed
- [ ] I have updated generated/plugin-related files if needed
- [ ] This change does not introduce known security issues