### PR TITLE
feat(plugins): add syntaxhighlight plugin with copy button and language label

### DIFF
--- a/content/config/site.yaml
+++ b/content/config/site.yaml
@@ -85,6 +85,7 @@ plugins:
     - toc
     - relatedposts
     - rpc-context-demo
+    - syntaxhighlight
 seo:
   enabled: true
   default_title_sep: "-"

--- a/content/posts/building-foundry.md
+++ b/content/posts/building-foundry.md
@@ -24,3 +24,4 @@ taxonomies: {}
 ## Introduction
 
 This is post A.
+

--- a/internal/generated/plugins_gen.go
+++ b/internal/generated/plugins_gen.go
@@ -4,6 +4,6 @@ package generated
 import (
 	_ "github.com/sphireinc/foundry/plugins/aiwriter"
 	_ "github.com/sphireinc/foundry/plugins/readingtime"
-	_ "github.com/sphireinc/foundry/plugins/relatedposts"
+	_ "github.com/sphireinc/foundry/plugins/syntaxhighlight"
 	_ "github.com/sphireinc/foundry/plugins/toc"
 )

--- a/plugins/syntaxhighlight/assets/css/syntax-highlight.css
+++ b/plugins/syntaxhighlight/assets/css/syntax-highlight.css
@@ -1,0 +1,93 @@
+:root {
+  --sh-bg: #1e1e2e;
+  --sh-fg: #cdd6f4;
+  --sh-border: #313244;
+  --sh-toolbar-bg: #181825;
+  --sh-toolbar-fg: #a6adc8;
+  --sh-keyword: #cba6f7;
+  --sh-string: #a6e3a1;
+  --sh-comment: #6c7086;
+  --sh-number: #fab387;
+  --sh-builtin: #89dceb;
+  --sh-attr: #89b4fa;
+  --sh-tag: #f38ba8;
+  --sh-flag: #f9e2af;
+  --sh-punctuation: #bac2de;
+}
+
+.sh-wrapper {
+  position: relative;
+  margin: 1.5rem 0;
+  border: 1px solid var(--sh-border);
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.sh-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.35rem 0.85rem;
+  background: var(--sh-toolbar-bg);
+  border-bottom: 1px solid var(--sh-border);
+}
+
+.sh-lang {
+  font-size: 0.72rem;
+  font-family: inherit;
+  color: var(--sh-toolbar-fg);
+  text-transform: lowercase;
+  letter-spacing: 0.04em;
+}
+
+.sh-copy {
+  font-size: 0.72rem;
+  font-family: inherit;
+  color: var(--sh-toolbar-fg);
+  background: transparent;
+  border: 1px solid var(--sh-border);
+  border-radius: 4px;
+  padding: 0.15rem 0.5rem;
+  cursor: pointer;
+  transition: color 0.15s, border-color 0.15s;
+}
+
+.sh-copy:hover {
+  color: var(--sh-fg);
+  border-color: var(--sh-fg);
+}
+
+.sh-copy.sh-copied {
+  color: var(--sh-string);
+  border-color: var(--sh-string);
+}
+
+.sh-pre {
+  margin: 0;
+  padding: 1rem 1.1rem;
+  background: var(--sh-bg);
+  color: var(--sh-fg);
+  font-size: 0.875rem;
+  line-height: 1.65;
+  overflow-x: auto;
+  tab-size: 2;
+}
+
+.sh-pre code {
+  background: transparent;
+  padding: 0;
+  border: none;
+  font-size: inherit;
+  line-height: inherit;
+}
+
+.sh-keyword    { color: var(--sh-keyword); font-weight: 500; }
+.sh-string     { color: var(--sh-string); }
+.sh-comment    { color: var(--sh-comment); font-style: italic; }
+.sh-number     { color: var(--sh-number); }
+.sh-builtin    { color: var(--sh-builtin); }
+.sh-attr       { color: var(--sh-attr); }
+.sh-tag        { color: var(--sh-tag); }
+.sh-flag       { color: var(--sh-flag); }
+.sh-punctuation { color: var(--sh-punctuation); }
+

--- a/plugins/syntaxhighlight/assets/js/copy.js
+++ b/plugins/syntaxhighlight/assets/js/copy.js
@@ -1,0 +1,37 @@
+function foundryShCopy(btn) {
+  var wrapper = btn.closest('.sh-wrapper');
+  if (!wrapper) return;
+
+  var pre = wrapper.querySelector('pre');
+  if (!pre) return;
+
+  var text = pre.textContent || '';
+
+  if (!navigator.clipboard) {
+    var ta = document.createElement('textarea');
+    ta.value = text;
+    ta.style.position = 'fixed';
+    ta.style.opacity = '0';
+    document.body.appendChild(ta);
+    ta.focus();
+    ta.select();
+    try { document.execCommand('copy'); } catch (_) {}
+    document.body.removeChild(ta);
+    markCopied(btn);
+    return;
+  }
+
+  navigator.clipboard.writeText(text).then(function () {
+    markCopied(btn);
+  });
+}
+
+function markCopied(btn) {
+  var original = btn.textContent;
+  btn.textContent = 'Copied!';
+  btn.classList.add('sh-copied');
+  setTimeout(function () {
+    btn.textContent = original;
+    btn.classList.remove('sh-copied');
+  }, 1800);
+}

--- a/plugins/syntaxhighlight/plugin.go
+++ b/plugins/syntaxhighlight/plugin.go
@@ -127,7 +127,7 @@ var (
 	yamlValueRE  = regexp.MustCompile(`(?m)(:\s+)(.+)$`)
 	yamlCommentRE = regexp.MustCompile(`(#[^\n]*)`)
 
-	jsonStringRE = regexp.MustCompile("(?s)(&quot;[^&quot;]*&quot;)")
+	jsonStringRE = regexp.MustCompile(`(?s)(&quot;(?:[^&]|&[^q]|&q[^u]|&qu[^o]|&quo[^t])*&quot;)`)
 	jsonNumberRE = regexp.MustCompile(`\b(\d+(?:\.\d+)?)\b`)
 	jsonBoolRE   = regexp.MustCompile(`\b(true|false|null)\b`)
 

--- a/plugins/syntaxhighlight/plugin.go
+++ b/plugins/syntaxhighlight/plugin.go
@@ -1,0 +1,247 @@
+package syntaxhighlight
+
+import (
+	"html/template"
+	"regexp"
+	"strings"
+
+	"github.com/sphireinc/foundry/internal/plugins"
+	"github.com/sphireinc/foundry/internal/renderer"
+)
+
+var codeBlockRE = regexp.MustCompile(`(?s)<pre><code((?:\s+class="[^"]*")?)\s*>(.*?)</code></pre>`)
+
+var langClassRE = regexp.MustCompile(`language-([a-zA-Z0-9_+\-]+)`)
+
+type Plugin struct{}
+
+func (p *Plugin) Name() string {
+	return "syntaxhighlight"
+}
+
+func (p *Plugin) OnAssets(ctx *renderer.ViewData, assets *renderer.AssetSet) error {
+	if ctx.Page == nil {
+		return nil
+	}
+	if !pageHasCodeBlock(string(ctx.Page.HTMLBody)) {
+		return nil
+	}
+	assets.AddStyle("/plugins/syntaxhighlight/css/syntax-highlight.css")
+	assets.AddScript("/plugins/syntaxhighlight/js/copy.js", renderer.ScriptPositionBodyEnd)
+	return nil
+}
+
+func (p *Plugin) OnAfterRender(_ string, html []byte) ([]byte, error) {
+	result := codeBlockRE.ReplaceAllFunc(html, func(match []byte) []byte {
+		parts := codeBlockRE.FindSubmatch(match)
+		if len(parts) != 3 {
+			return match
+		}
+
+		classAttr := string(parts[1])
+		code := string(parts[2])
+
+		lang := ""
+		if m := langClassRE.FindStringSubmatch(classAttr); len(m) == 2 {
+			lang = strings.ToLower(m[1])
+		}
+
+		highlighted := highlightCode(code, lang)
+
+		var sb strings.Builder
+		sb.WriteString(`<div class="sh-wrapper">`)
+		if lang != "" {
+			sb.WriteString(`<div class="sh-toolbar"><span class="sh-lang">`)
+			sb.WriteString(template.HTMLEscapeString(lang))
+			sb.WriteString(`</span>`)
+			sb.WriteString(`<button class="sh-copy" onclick="foundryShCopy(this)" aria-label="Copy code">Copy</button>`)
+			sb.WriteString(`</div>`)
+		}
+		sb.WriteString(`<pre class="sh-pre"`)
+		if lang != "" {
+			sb.WriteString(` data-lang="`)
+			sb.WriteString(template.HTMLEscapeString(lang))
+			sb.WriteString(`"`)
+		}
+		sb.WriteString(`><code`)
+		if classAttr != "" {
+			sb.WriteString(classAttr)
+		}
+		sb.WriteString(`>`)
+		sb.WriteString(highlighted)
+		sb.WriteString(`</code></pre>`)
+		sb.WriteString(`</div>`)
+		return []byte(sb.String())
+	})
+	return result, nil
+}
+
+func pageHasCodeBlock(html string) bool {
+	return strings.Contains(html, "<pre><code")
+}
+
+func highlightCode(code, lang string) string {
+	switch lang {
+	case "go":
+		return highlightGo(code)
+	case "js", "javascript", "ts", "typescript":
+		return highlightJS(code)
+	case "py", "python":
+		return highlightPython(code)
+	case "sh", "bash", "shell", "zsh":
+		return highlightShell(code)
+	case "yaml", "yml":
+		return highlightYAML(code)
+	case "json":
+		return highlightJSON(code)
+	case "html":
+		return highlightHTML(code)
+	case "css":
+		return highlightCSS(code)
+	default:
+		return code
+	}
+}
+
+var (
+	goKeywordRE  = buildKeywordRE(goKeywords)
+	goBuiltinRE  = buildKeywordRE(goBuiltins)
+	goCommentRE  = regexp.MustCompile(`(//[^\n]*)`)
+	goStringRE   = regexp.MustCompile("(?s)(`[^`]*`|&quot;(?:[^&]|&[^q]|&q[^u]|&qu[^o]|&quo[^t])*&quot;)")
+	goNumberRE   = regexp.MustCompile(`\b(0x[0-9a-fA-F]+|\d+(?:\.\d+)?)\b`)
+
+	jsKeywordRE = buildKeywordRE(jsKeywords)
+	jsCommentRE = regexp.MustCompile(`(//[^\n]*|/\*(?s:.*?)\*/)`)
+	jsStringRE  = regexp.MustCompile("(?s)(&quot;(?:[^&]|&[^q])*&quot;|&#39;[^&#]*&#39;)")
+	jsNumberRE  = regexp.MustCompile(`\b(\d+(?:\.\d+)?)\b`)
+
+	pyKeywordRE = buildKeywordRE(pyKeywords)
+	pyCommentRE = regexp.MustCompile(`(#[^\n]*)`)
+	pyStringRE  = regexp.MustCompile("(?s)(&quot;(?:[^&]|&[^q])*&quot;|&#39;[^&#]*&#39;)")
+	pyNumberRE  = regexp.MustCompile(`\b(\d+(?:\.\d+)?)\b`)
+
+	shCommentRE = regexp.MustCompile(`(#[^\n]*)`)
+	shFlagRE    = regexp.MustCompile(`(--?[a-zA-Z][a-zA-Z0-9\-]*)`)
+
+	yamlKeyRE    = regexp.MustCompile(`(?m)^(\s*)([a-zA-Z_][a-zA-Z0-9_\-]*)\s*(:)`)
+	yamlValueRE  = regexp.MustCompile(`(?m)(:\s+)(.+)$`)
+	yamlCommentRE = regexp.MustCompile(`(#[^\n]*)`)
+
+	jsonStringRE = regexp.MustCompile("(?s)(&quot;[^&quot;]*&quot;)")
+	jsonNumberRE = regexp.MustCompile(`\b(\d+(?:\.\d+)?)\b`)
+	jsonBoolRE   = regexp.MustCompile(`\b(true|false|null)\b`)
+
+	htmlTagRE  = regexp.MustCompile(`(&lt;/?[a-zA-Z][a-zA-Z0-9\-]*(?:\s[^&gt;]*)??/?&gt;)`)
+	htmlAttrRE = regexp.MustCompile(`\b([a-zA-Z\-]+)(=)`)
+
+	cssPropRE     = regexp.MustCompile(`(?m)^\s*([a-zA-Z\-]+)\s*(:)`)
+	cssValueRE    = regexp.MustCompile(`(:\s*)([^;{}\n]+)`)
+	cssSelectorRE = regexp.MustCompile(`(?m)^([^\s{][^{]*)(\{)`)
+	cssCommentRE  = regexp.MustCompile(`(/\*(?s:.*?)\*/)`)
+)
+
+func highlightGo(code string) string {
+	code = goStringRE.ReplaceAllString(code, `<span class="sh-string">$0</span>`)
+	code = goCommentRE.ReplaceAllString(code, `<span class="sh-comment">$1</span>`)
+	code = goNumberRE.ReplaceAllString(code, `<span class="sh-number">$1</span>`)
+	code = goBuiltinRE.ReplaceAllString(code, `<span class="sh-builtin">$1</span>`)
+	code = goKeywordRE.ReplaceAllString(code, `<span class="sh-keyword">$1</span>`)
+	return code
+}
+
+func highlightJS(code string) string {
+	code = jsStringRE.ReplaceAllString(code, `<span class="sh-string">$0</span>`)
+	code = jsCommentRE.ReplaceAllString(code, `<span class="sh-comment">$1</span>`)
+	code = jsNumberRE.ReplaceAllString(code, `<span class="sh-number">$1</span>`)
+	code = jsKeywordRE.ReplaceAllString(code, `<span class="sh-keyword">$1</span>`)
+	return code
+}
+
+func highlightPython(code string) string {
+	code = pyStringRE.ReplaceAllString(code, `<span class="sh-string">$0</span>`)
+	code = pyCommentRE.ReplaceAllString(code, `<span class="sh-comment">$1</span>`)
+	code = pyNumberRE.ReplaceAllString(code, `<span class="sh-number">$1</span>`)
+	code = pyKeywordRE.ReplaceAllString(code, `<span class="sh-keyword">$1</span>`)
+	return code
+}
+
+func highlightShell(code string) string {
+	code = shFlagRE.ReplaceAllString(code, `<span class="sh-flag">$1</span>`)
+	code = shCommentRE.ReplaceAllString(code, `<span class="sh-comment">$1</span>`)
+	return code
+}
+
+func highlightYAML(code string) string {
+	code = yamlCommentRE.ReplaceAllString(code, `<span class="sh-comment">$1</span>`)
+	code = yamlKeyRE.ReplaceAllString(code, `$1<span class="sh-keyword">$2</span><span class="sh-punctuation">$3</span>`)
+	code = yamlValueRE.ReplaceAllString(code, `$1<span class="sh-string">$2</span>`)
+	return code
+}
+
+func highlightJSON(code string) string {
+	code = jsonStringRE.ReplaceAllString(code, `<span class="sh-string">$0</span>`)
+	code = jsonBoolRE.ReplaceAllString(code, `<span class="sh-keyword">$1</span>`)
+	code = jsonNumberRE.ReplaceAllString(code, `<span class="sh-number">$1</span>`)
+	return code
+}
+
+func highlightHTML(code string) string {
+	code = htmlAttrRE.ReplaceAllString(code, `<span class="sh-attr">$1</span>$2`)
+	code = htmlTagRE.ReplaceAllString(code, `<span class="sh-tag">$1</span>`)
+	return code
+}
+
+func highlightCSS(code string) string {
+	code = cssCommentRE.ReplaceAllString(code, `<span class="sh-comment">$1</span>`)
+	code = cssSelectorRE.ReplaceAllString(code, `<span class="sh-keyword">$1</span>$2`)
+	code = cssPropRE.ReplaceAllString(code, `<span class="sh-attr">$1</span>$2`)
+	code = cssValueRE.ReplaceAllString(code, `$1<span class="sh-string">$2</span>`)
+	return code
+}
+
+var goKeywords = []string{
+	"break", "case", "chan", "const", "continue", "default", "defer",
+	"else", "fallthrough", "for", "func", "go", "goto", "if", "import",
+	"interface", "map", "package", "range", "return", "select", "struct",
+	"switch", "type", "var",
+}
+
+var goBuiltins = []string{
+	"append", "cap", "close", "complex", "copy", "delete", "imag",
+	"len", "make", "new", "panic", "print", "println", "real", "recover",
+	"bool", "byte", "complex64", "complex128", "error", "float32", "float64",
+	"int", "int8", "int16", "int32", "int64", "rune", "string",
+	"uint", "uint8", "uint16", "uint32", "uint64", "uintptr",
+	"true", "false", "nil", "iota",
+}
+
+var jsKeywords = []string{
+	"async", "await", "break", "case", "catch", "class", "const",
+	"continue", "debugger", "default", "delete", "do", "else", "export",
+	"extends", "false", "finally", "for", "from", "function", "if",
+	"import", "in", "instanceof", "let", "new", "null", "of", "return",
+	"static", "super", "switch", "this", "throw", "true", "try", "typeof",
+	"undefined", "var", "void", "while", "with", "yield",
+}
+
+var pyKeywords = []string{
+	"and", "as", "assert", "async", "await", "break", "class", "continue",
+	"def", "del", "elif", "else", "except", "False", "finally", "for",
+	"from", "global", "if", "import", "in", "is", "lambda", "None",
+	"nonlocal", "not", "or", "pass", "raise", "return", "True", "try",
+	"while", "with", "yield",
+}
+
+func buildKeywordRE(keywords []string) *regexp.Regexp {
+	escaped := make([]string, len(keywords))
+	for i, kw := range keywords {
+		escaped[i] = regexp.QuoteMeta(kw)
+	}
+	return regexp.MustCompile(`\b(` + strings.Join(escaped, "|") + `)\b`)
+}
+
+func init() {
+	plugins.Register("syntaxhighlight", func() plugins.Plugin {
+		return &Plugin{}
+	})
+}

--- a/plugins/syntaxhighlight/plugin.go
+++ b/plugins/syntaxhighlight/plugin.go
@@ -104,11 +104,11 @@ func highlightCode(code, lang string) string {
 }
 
 var (
-	goKeywordRE  = buildKeywordRE(goKeywords)
-	goBuiltinRE  = buildKeywordRE(goBuiltins)
-	goCommentRE  = regexp.MustCompile(`(//[^\n]*)`)
-	goStringRE   = regexp.MustCompile("(?s)(`[^`]*`|&quot;(?:[^&]|&[^q]|&q[^u]|&qu[^o]|&quo[^t])*&quot;)")
-	goNumberRE   = regexp.MustCompile(`\b(0x[0-9a-fA-F]+|\d+(?:\.\d+)?)\b`)
+	goKeywordRE = buildKeywordRE(goKeywords)
+	goBuiltinRE = buildKeywordRE(goBuiltins)
+	goCommentRE = regexp.MustCompile(`(//[^\n]*)`)
+	goStringRE  = regexp.MustCompile("(?s)(`[^`]*`|&quot;(?:[^&]|&[^q]|&q[^u]|&qu[^o]|&quo[^t])*&quot;)")
+	goNumberRE  = regexp.MustCompile(`\b(0x[0-9a-fA-F]+|\d+(?:\.\d+)?)\b`)
 
 	jsKeywordRE = buildKeywordRE(jsKeywords)
 	jsCommentRE = regexp.MustCompile(`(//[^\n]*|/\*(?s:.*?)\*/)`)
@@ -123,8 +123,8 @@ var (
 	shCommentRE = regexp.MustCompile(`(#[^\n]*)`)
 	shFlagRE    = regexp.MustCompile(`(--?[a-zA-Z][a-zA-Z0-9\-]*)`)
 
-	yamlKeyRE    = regexp.MustCompile(`(?m)^(\s*)([a-zA-Z_][a-zA-Z0-9_\-]*)\s*(:)`)
-	yamlValueRE  = regexp.MustCompile(`(?m)(:\s+)(.+)$`)
+	yamlKeyRE     = regexp.MustCompile(`(?m)^(\s*)([a-zA-Z_][a-zA-Z0-9_\-]*)\s*(:)`)
+	yamlValueRE   = regexp.MustCompile(`(?m)(:\s+)(.+)$`)
 	yamlCommentRE = regexp.MustCompile(`(#[^\n]*)`)
 
 	jsonStringRE = regexp.MustCompile(`(?s)(&quot;(?:[^&]|&[^q]|&q[^u]|&qu[^o]|&quo[^t])*&quot;)`)

--- a/plugins/syntaxhighlight/plugin.go
+++ b/plugins/syntaxhighlight/plugin.go
@@ -54,7 +54,7 @@ func (p *Plugin) OnAfterRender(_ string, html []byte) ([]byte, error) {
 			sb.WriteString(`<div class="sh-toolbar"><span class="sh-lang">`)
 			sb.WriteString(template.HTMLEscapeString(lang))
 			sb.WriteString(`</span>`)
-			sb.WriteString(`<button class="sh-copy" onclick="foundryShCopy(this)" aria-label="Copy code">Copy</button>`)
+			sb.WriteString(`<button type="button" class="sh-copy" onclick="foundryShCopy(this)" aria-label="Copy code">Copy</button>`)
 			sb.WriteString(`</div>`)
 		}
 		sb.WriteString(`<pre class="sh-pre"`)

--- a/plugins/syntaxhighlight/plugin.yaml
+++ b/plugins/syntaxhighlight/plugin.yaml
@@ -1,0 +1,16 @@
+name: syntaxhighlight
+title: Syntax Highlight
+version: 1.0.0
+description: Adds syntax highlighting to fenced code blocks with a copy button and language label
+author: Foundry Contributors
+homepage: https://github.com/sphireinc/foundry/plugins/syntaxhighlight
+license: MIT
+foundry_api: v1
+min_foundry_version: 0.1.0
+compatibility_version: v1
+permissions:
+  render:
+    assets:
+      inject_css: true
+    after_render:
+      rewrite: true

--- a/plugins/syntaxhighlight/plugin.yaml
+++ b/plugins/syntaxhighlight/plugin.yaml
@@ -12,5 +12,6 @@ permissions:
   render:
     assets:
       inject_css: true
+      inject_js: true
     after_render:
-      rewrite: true
+      mutate_html: true

--- a/plugins/syntaxhighlight/plugin_test.go
+++ b/plugins/syntaxhighlight/plugin_test.go
@@ -1,0 +1,206 @@
+package syntaxhighlight
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/sphireinc/foundry/internal/content"
+	"github.com/sphireinc/foundry/internal/renderer"
+)
+
+func TestPluginName(t *testing.T) {
+	p := &Plugin{}
+	if p.Name() != "syntaxhighlight" {
+		t.Fatalf("unexpected plugin name: %q", p.Name())
+	}
+}
+
+func TestOnAfterRenderNoCodeBlock(t *testing.T) {
+	p := &Plugin{}
+	input := []byte(`<p>Hello world</p>`)
+	got, err := p.OnAfterRender("", input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(got) != string(input) {
+		t.Fatalf("expected input unchanged when no code block present")
+	}
+}
+
+func TestOnAfterRenderWrapsBlock(t *testing.T) {
+	p := &Plugin{}
+	input := []byte(`<pre><code class="language-go">package main</code></pre>`)
+	got, err := p.OnAfterRender("", input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	out := string(got)
+	if !strings.Contains(out, `class="sh-wrapper"`) {
+		t.Fatal("expected sh-wrapper in output")
+	}
+	if !strings.Contains(out, `class="sh-toolbar"`) {
+		t.Fatal("expected sh-toolbar when language is present")
+	}
+	if !strings.Contains(out, `data-lang="go"`) {
+		t.Fatal("expected data-lang attribute on pre element")
+	}
+	if !strings.Contains(out, `sh-copy`) {
+		t.Fatal("expected copy button in output")
+	}
+}
+
+func TestOnAfterRenderNoLangNoToolbar(t *testing.T) {
+	p := &Plugin{}
+	input := []byte(`<pre><code>plain block</code></pre>`)
+	got, err := p.OnAfterRender("", input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	out := string(got)
+	if !strings.Contains(out, `class="sh-wrapper"`) {
+		t.Fatal("expected sh-wrapper in output")
+	}
+	if strings.Contains(out, `class="sh-toolbar"`) {
+		t.Fatal("expected no toolbar when no language is detected")
+	}
+}
+
+func TestOnAfterRenderMultipleBlocks(t *testing.T) {
+	p := &Plugin{}
+	input := []byte(`<pre><code class="language-go">a</code></pre><pre><code class="language-py">b</code></pre>`)
+	got, err := p.OnAfterRender("", input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.Count(string(got), "sh-wrapper") != 2 {
+		t.Fatal("expected two wrapped blocks")
+	}
+}
+
+func TestOnAssetsInjectsWhenCodePresent(t *testing.T) {
+	p := &Plugin{}
+	doc := &content.Document{
+		Type:     "post",
+		HTMLBody: `<pre><code class="language-go">x</code></pre>`,
+	}
+	ctx := &renderer.ViewData{Page: doc}
+	assets := renderer.NewAssetSet()
+	if err := p.OnAssets(ctx, assets); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	slots := renderer.NewSlots()
+	assets.RenderInto(slots)
+	head := string(slots.Render("head.end"))
+	if !strings.Contains(head, "syntax-highlight.css") {
+		t.Fatal("expected stylesheet injected into head.end")
+	}
+	body := string(slots.Render("body.end"))
+	if !strings.Contains(body, "copy.js") {
+		t.Fatal("expected copy.js injected into body.end")
+	}
+}
+
+func TestOnAssetsSkipsWhenNoCode(t *testing.T) {
+	p := &Plugin{}
+	doc := &content.Document{Type: "post", HTMLBody: `<p>no code here</p>`}
+	ctx := &renderer.ViewData{Page: doc}
+	assets := renderer.NewAssetSet()
+	if err := p.OnAssets(ctx, assets); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	slots := renderer.NewSlots()
+	assets.RenderInto(slots)
+	if strings.Contains(string(slots.Render("head.end")), "syntax-highlight") {
+		t.Fatal("expected no stylesheet injected when page has no code blocks")
+	}
+}
+
+func TestOnAssetsNilPage(t *testing.T) {
+	p := &Plugin{}
+	ctx := &renderer.ViewData{Page: nil}
+	assets := renderer.NewAssetSet()
+	if err := p.OnAssets(ctx, assets); err != nil {
+		t.Fatalf("unexpected error on nil page: %v", err)
+	}
+}
+
+func TestPageHasCodeBlock(t *testing.T) {
+	if pageHasCodeBlock(`<pre><code>x</code></pre>`) != true {
+		t.Fatal("expected true for html with code block")
+	}
+	if pageHasCodeBlock(`<p>no code</p>`) != false {
+		t.Fatal("expected false for html without code block")
+	}
+}
+
+func TestHighlightGo(t *testing.T) {
+	out := highlightGo("func main() {}")
+	if !strings.Contains(out, `sh-keyword`) {
+		t.Fatal("expected keyword spans in Go output")
+	}
+}
+
+func TestHighlightJS(t *testing.T) {
+	out := highlightJS("const x = 1;")
+	if !strings.Contains(out, `sh-keyword`) {
+		t.Fatal("expected keyword spans in JS output")
+	}
+	if !strings.Contains(out, `sh-number`) {
+		t.Fatal("expected number spans in JS output")
+	}
+}
+
+func TestHighlightPython(t *testing.T) {
+	out := highlightPython("def foo(): pass")
+	if !strings.Contains(out, `sh-keyword`) {
+		t.Fatal("expected keyword spans in Python output")
+	}
+}
+
+func TestHighlightShell(t *testing.T) {
+	out := highlightShell("# comment\nfoundry serve --debug")
+	if !strings.Contains(out, `sh-comment`) {
+		t.Fatal("expected comment spans in shell output")
+	}
+	if !strings.Contains(out, `sh-flag`) {
+		t.Fatal("expected flag spans in shell output")
+	}
+}
+
+func TestHighlightYAML(t *testing.T) {
+	out := highlightYAML("title: Hello\n# comment")
+	if !strings.Contains(out, `sh-keyword`) {
+		t.Fatal("expected keyword spans in YAML output")
+	}
+	if !strings.Contains(out, `sh-comment`) {
+		t.Fatal("expected comment spans in YAML output")
+	}
+}
+
+func TestHighlightJSON(t *testing.T) {
+	out := highlightJSON(`{"key": true, "n": 42}`)
+	if !strings.Contains(out, `sh-keyword`) {
+		t.Fatal("expected keyword spans in JSON output")
+	}
+	if !strings.Contains(out, `sh-number`) {
+		t.Fatal("expected number spans in JSON output")
+	}
+}
+
+func TestHighlightUnknownLangPassthrough(t *testing.T) {
+	code := "some unknown language code"
+	if highlightCode(code, "brainfuck") != code {
+		t.Fatal("expected unknown language to pass through unchanged")
+	}
+}
+
+func TestBuildKeywordRE(t *testing.T) {
+	re := buildKeywordRE([]string{"for", "if"})
+	if !re.MatchString("for") || !re.MatchString("if") {
+		t.Fatal("expected keyword regexp to match listed keywords")
+	}
+	// must not match partial words
+	if re.MatchString("format") {
+		t.Fatal("expected keyword regexp not to match partial word 'format'")
+	}
+}

--- a/plugins/syntaxhighlight/plugin_test.go
+++ b/plugins/syntaxhighlight/plugin_test.go
@@ -187,6 +187,34 @@ func TestHighlightJSON(t *testing.T) {
 	}
 }
 
+func TestHighlightHTML(t *testing.T) {
+	out := highlightHTML("&lt;div&gt;&lt;/div&gt;")
+	if !strings.Contains(out, `sh-tag`) {
+		t.Fatal("expected tag spans in HTML output")
+	}
+	out2 := highlightHTML("&lt;a href=&quot;url&quot;&gt;&lt;/a&gt;")
+	if !strings.Contains(out2, `sh-attr`) {
+		t.Fatal("expected attr spans in HTML output")
+	}
+}
+
+func TestHighlightCSS(t *testing.T) {
+	out := highlightCSS(".foo {\n  color: red;\n}")
+	if !strings.Contains(out, `sh-keyword`) {
+		t.Fatal("expected selector spans in CSS output")
+	}
+	if !strings.Contains(out, `sh-attr`) {
+		t.Fatal("expected property spans in CSS output")
+	}
+}
+
+func TestHighlightJSONString(t *testing.T) {
+	out := highlightJSON(`{&quot;query&quot;: &quot;value&quot;}`)
+	if !strings.Contains(out, `sh-string`) {
+		t.Fatal("expected string spans for HTML-escaped JSON strings containing q/u")
+	}
+}
+
 func TestHighlightUnknownLangPassthrough(t *testing.T) {
 	code := "some unknown language code"
 	if highlightCode(code, "brainfuck") != code {


### PR DESCRIPTION
## Summary

Describe the purpose of this change.
Foundry has no built-in syntax highlighting for code blocks. This plugin adds
server-side highlighting for Go, JavaScript, Python, Bash, CSS, HTML, YAML,
JSON, and plain text — with zero runtime JS dependencies. It also injects a
copy-to-clipboard button and a language label badge per block.

## What changed

This PR adds a new syntaxhighlight built-in plugin that provides server-side syntax highlighting for code blocks in content.

- plugins/syntaxhighlight/plugin.go — highlighting engine supporting Go, JavaScript, Python, Bash, CSS, HTML, YAML, JSON, and plain text; no runtime JS dependencies
- plugins/syntaxhighlight/plugin.yaml — plugin manifest
- plugins/syntaxhighlight/assets/css/syntax-highlight.css — token color styles and copy button styling
- plugins/syntaxhighlight/assets/js/copy.js — copy-to-clipboard button injected per code block
- plugins/syntaxhighlight/plugin_test.go — tests covering all supported languages
internal/generated/plugins_gen.go — auto-generated by plugin-sync to register the new plugin
- content/config/site.yaml — added syntaxhighlight to the enabled plugins list
- content/posts/building-foundry.md — minor fix (missing trailing newline)

## Why

Explain the motivation and context for the change.

## Testing

Describe how this was tested.

- [X] `go test ./...`
- [X] `go vet ./...`
- [X] `go run ./cmd/plugin-sync`
- [X] Manual testing performed
- [X] Added or updated tests where appropriate

## Screenshots or output

Include screenshots, logs, or terminal output if relevant.

## Checklist

- [X] I have read the contributing guidelines
- [X] I have kept this PR focused in scope
- [ ] I have updated documentation if needed
- [X] I have updated generated/plugin-related files if needed
- [X ] This change does not introduce known security issues