### PR TITLE
fix symlink vuln and add tests to ensure regression doesn't occur

### DIFF
--- a/internal/admin/http/router.go
+++ b/internal/admin/http/router.go
@@ -222,6 +222,10 @@ func (r *Router) handlePluginExtensionAsset(w http.ResponseWriter, req *http.Req
 		http.NotFound(w, req)
 		return
 	}
+	if err := safepath.EnsureNoSymlinkEscape(root, target); err != nil {
+		http.NotFound(w, req)
+		return
+	}
 	info, err := os.Stat(target)
 	if err != nil || info.IsDir() {
 		http.NotFound(w, req)

--- a/internal/admin/http/router_test.go
+++ b/internal/admin/http/router_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -1032,11 +1033,18 @@ func TestAdminCustomPathRoutesAndAssets(t *testing.T) {
 	cfg := testConfig(t)
 	cfg.Admin.Path = "/cms-admin"
 	cfg.ApplyDefaults()
+	outside := filepath.Join(t.TempDir(), "secret.js")
+	if err := os.WriteFile(outside, []byte(`export default function secret(){}`), 0o644); err != nil {
+		t.Fatalf("write outside plugin asset: %v", err)
+	}
 	if err := os.MkdirAll(filepath.Join(cfg.PluginsDir, "search", "admin"), 0o755); err != nil {
 		t.Fatalf("mkdir plugin admin assets: %v", err)
 	}
 	if err := os.WriteFile(filepath.Join(cfg.PluginsDir, "search", "admin", "console.js"), []byte(`export default function () {}`), 0o644); err != nil {
 		t.Fatalf("write plugin admin asset: %v", err)
+	}
+	if err := os.Symlink(outside, filepath.Join(cfg.PluginsDir, "search", "admin", "linked.js")); err != nil {
+		t.Skipf("symlink not supported on %s: %v", runtime.GOOS, err)
 	}
 	if err := os.WriteFile(filepath.Join(cfg.PluginsDir, "search", "admin", "secret.txt"), []byte(`top-secret`), 0o644); err != nil {
 		t.Fatalf("write undeclared plugin admin asset: %v", err)
@@ -1046,7 +1054,13 @@ func TestAdminCustomPathRoutesAndAssets(t *testing.T) {
 			"search": {
 				Name: "search",
 				AdminExtensions: plugins.AdminExtensions{
-					Pages: []plugins.AdminPage{{Key: "search-console", Title: "Search Console", Route: "/plugins/search", Module: "admin/console.js"}},
+					Pages: []plugins.AdminPage{{
+						Key:    "search-console",
+						Title:  "Search Console",
+						Route:  "/plugins/search",
+						Module: "admin/console.js",
+						Styles: []string{"admin/linked.js"},
+					}},
 				},
 			},
 		}
@@ -1104,6 +1118,15 @@ func TestAdminCustomPathRoutesAndAssets(t *testing.T) {
 	mux.ServeHTTP(rr, req)
 	if rr.Code != http.StatusNotFound {
 		t.Fatalf("expected undeclared plugin asset to be hidden, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/cms-admin/extensions/search/admin/linked.js", nil)
+	req.RemoteAddr = "127.0.0.1:10000"
+	req.Header.Set("X-Foundry-Admin-Token", cfg.Admin.AccessToken)
+	rr = httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("expected symlinked plugin asset to be hidden, got %d: %s", rr.Code, rr.Body.String())
 	}
 }
 

--- a/internal/content/loader.go
+++ b/internal/content/loader.go
@@ -15,6 +15,7 @@ import (
 	"github.com/sphireinc/foundry/internal/i18n"
 	"github.com/sphireinc/foundry/internal/lifecycle"
 	"github.com/sphireinc/foundry/internal/markup"
+	"github.com/sphireinc/foundry/internal/safepath"
 	"github.com/sphireinc/foundry/internal/theme"
 )
 
@@ -141,6 +142,9 @@ func (l *Loader) loadSection(graph *SiteGraph, docType, root string) error {
 		}
 		if info.IsDir() || filepath.Ext(path) != ".md" || lifecycle.IsDerivedPath(path) {
 			return nil
+		}
+		if err := safepath.EnsureNoSymlinkEscape(root, path); err != nil {
+			return err
 		}
 
 		if err := l.hooks.OnContentDiscovered(path); err != nil {

--- a/internal/content/loader_test.go
+++ b/internal/content/loader_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -164,6 +165,23 @@ func TestLoaderDefaultsAndErrors(t *testing.T) {
 	}
 	if _, err := loader.loadDocument(filepath.Join(cfg.ContentDir, cfg.Content.PagesDir, "missing.md"), "missing.md", "en", true, "page"); err == nil {
 		t.Fatal("expected read error")
+	}
+}
+
+func TestLoaderRejectsSymlinkedContent(t *testing.T) {
+	cfg := testLoaderConfig(t)
+	outside := filepath.Join(t.TempDir(), "secret.md")
+	if err := os.WriteFile(outside, []byte("---\ntitle: Secret\n---\n\nsecret"), 0o600); err != nil {
+		t.Fatalf("write outside content: %v", err)
+	}
+	link := filepath.Join(cfg.ContentDir, cfg.Content.PagesDir, "linked.md")
+	if err := os.Symlink(outside, link); err != nil {
+		t.Skipf("symlink not supported on %s: %v", runtime.GOOS, err)
+	}
+
+	loader := NewLoader(cfg, nil, true)
+	if _, err := loader.Load(context.Background()); err == nil {
+		t.Fatal("expected loader to reject symlinked content")
 	}
 }
 

--- a/internal/generated/plugins_gen.go
+++ b/internal/generated/plugins_gen.go
@@ -2,8 +2,8 @@
 package generated
 
 import (
-	_ "github.com/sphireinc/foundry/plugins/aiwriter"
 	_ "github.com/sphireinc/foundry/plugins/readingtime"
+	_ "github.com/sphireinc/foundry/plugins/relatedposts"
 	_ "github.com/sphireinc/foundry/plugins/syntaxhighlight"
 	_ "github.com/sphireinc/foundry/plugins/toc"
 )

--- a/internal/renderer/renderer.go
+++ b/internal/renderer/renderer.go
@@ -18,6 +18,7 @@ import (
 	"github.com/sphireinc/foundry/internal/config"
 	"github.com/sphireinc/foundry/internal/content"
 	"github.com/sphireinc/foundry/internal/platformapi"
+	"github.com/sphireinc/foundry/internal/safepath"
 	"github.com/sphireinc/foundry/internal/theme"
 )
 
@@ -1135,6 +1136,12 @@ func (r *Renderer) renderTemplate(name string, targetURL string, data ViewData) 
 
 	files := []string{basePath, pagePath}
 	files = append(files, partials...)
+	themeRoot := filepath.Join(r.cfg.ThemesDir, r.cfg.Theme)
+	for _, path := range files {
+		if err := safepath.EnsureNoSymlinkEscape(themeRoot, path); err != nil {
+			return nil, fmt.Errorf("parse templates: %w", err)
+		}
+	}
 
 	// These template functions are the stable extension helpers exposed to
 	// frontend themes:

--- a/internal/renderer/renderer_test.go
+++ b/internal/renderer/renderer_test.go
@@ -5,6 +5,7 @@ import (
 	"html/template"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -445,6 +446,41 @@ func TestRendererHookFailuresAndBuild(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(cfg.PublicDir, "__foundry", "sdk", "frontend", "index.js")); err != nil {
 		t.Fatalf("expected frontend sdk asset to be copied: %v", err)
+	}
+}
+
+func TestRendererRejectsSymlinkedThemeLayout(t *testing.T) {
+	cfg := testRendererConfig(t)
+	writeRendererTheme(t, cfg)
+
+	outside := filepath.Join(t.TempDir(), "base.html")
+	if err := os.WriteFile(outside, []byte(`{{ define "base" }}symlinked{{ end }}`), 0o644); err != nil {
+		t.Fatalf("write outside layout: %v", err)
+	}
+	basePath := filepath.Join(cfg.ThemesDir, cfg.Theme, "layouts", "base.html")
+	if err := os.Remove(basePath); err != nil {
+		t.Fatalf("remove base layout: %v", err)
+	}
+	if err := os.Symlink(outside, basePath); err != nil {
+		t.Skipf("symlink not supported on %s: %v", runtime.GOOS, err)
+	}
+
+	r := New(cfg, theme.NewManager(cfg.ThemesDir, cfg.Theme), nil)
+	graph := content.NewSiteGraph(cfg)
+	graph.Add(&content.Document{
+		ID:         "page-1",
+		Type:       "page",
+		Lang:       cfg.DefaultLang,
+		Title:      "About",
+		Slug:       "about",
+		URL:        "/about/",
+		Layout:     "page",
+		SourcePath: filepath.ToSlash(filepath.Join(cfg.ContentDir, "pages", "about.md")),
+		HTMLBody:   template.HTML("<p>About</p>"),
+	})
+
+	if _, err := r.RenderURL(graph, "/about/", false); err == nil {
+		t.Fatal("expected symlinked layout to be rejected")
 	}
 }
 

--- a/internal/safepath/symlink.go
+++ b/internal/safepath/symlink.go
@@ -1,0 +1,80 @@
+package safepath
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// EnsureNoSymlinkEscape rejects paths that resolve outside root after symlink
+// resolution and also rejects symlinked path components inside the root.
+//
+// It is intended for security-sensitive filesystem reads and writes where a
+// lexical path check is not sufficient.
+func EnsureNoSymlinkEscape(root, target string) error {
+	rootAbs, err := filepath.Abs(root)
+	if err != nil {
+		return err
+	}
+	if info, err := os.Lstat(rootAbs); err == nil {
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("path must stay inside %s after resolving symlinks", root)
+		}
+	} else if !os.IsNotExist(err) {
+		return err
+	}
+	targetAbs, err := filepath.Abs(target)
+	if err != nil {
+		return err
+	}
+
+	rel, err := filepath.Rel(rootAbs, targetAbs)
+	if err != nil {
+		return err
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return fmt.Errorf("path must stay inside %s", root)
+	}
+	if rel == "." {
+		return nil
+	}
+
+	current := rootAbs
+	for _, part := range strings.Split(rel, string(filepath.Separator)) {
+		current = filepath.Join(current, part)
+
+		info, err := os.Lstat(current)
+		if err != nil {
+			if os.IsNotExist(err) {
+				ok, err := IsWithinRoot(rootAbs, current)
+				if err != nil {
+					return err
+				}
+				if !ok {
+					return fmt.Errorf("path must stay inside %s", root)
+				}
+				continue
+			}
+			return err
+		}
+
+		if info.Mode()&os.ModeSymlink == 0 {
+			continue
+		}
+
+		resolved, err := filepath.EvalSymlinks(current)
+		if err != nil {
+			return err
+		}
+		ok, err := IsWithinRoot(rootAbs, resolved)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			return fmt.Errorf("path must stay inside %s after resolving symlinks", root)
+		}
+	}
+
+	return nil
+}

--- a/internal/safepath/symlink.go
+++ b/internal/safepath/symlink.go
@@ -13,19 +13,37 @@ import (
 // It is intended for security-sensitive filesystem reads and writes where a
 // lexical path check is not sufficient.
 func EnsureNoSymlinkEscape(root, target string) error {
+	root = strings.TrimSpace(root)
+	if root == "" {
+		return fmt.Errorf("root path cannot be empty")
+	}
+	target = strings.TrimSpace(target)
+	if target == "" {
+		return fmt.Errorf("target path cannot be empty")
+	}
+
 	rootAbs, err := filepath.Abs(root)
 	if err != nil {
 		return err
 	}
+	targetAbs, err := filepath.Abs(target)
+	if err != nil {
+		return err
+	}
+
+	ok, err := IsWithinRoot(rootAbs, targetAbs)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return fmt.Errorf("path must stay inside %s", root)
+	}
+
 	if info, err := os.Lstat(rootAbs); err == nil {
 		if info.Mode()&os.ModeSymlink != 0 {
 			return fmt.Errorf("path must stay inside %s after resolving symlinks", root)
 		}
 	} else if !os.IsNotExist(err) {
-		return err
-	}
-	targetAbs, err := filepath.Abs(target)
-	if err != nil {
 		return err
 	}
 

--- a/internal/safepath/symlink_test.go
+++ b/internal/safepath/symlink_test.go
@@ -1,0 +1,78 @@
+package safepath
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestEnsureNoSymlinkEscape(t *testing.T) {
+	root := t.TempDir()
+	nested := filepath.Join(root, "content", "posts")
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatalf("mkdir nested: %v", err)
+	}
+
+	target := filepath.Join(nested, "hello.md")
+	if err := os.WriteFile(target, []byte("hello"), 0o644); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+	if err := EnsureNoSymlinkEscape(filepath.Join(root, "content"), target); err != nil {
+		t.Fatalf("expected safe path to pass: %v", err)
+	}
+
+	outside := filepath.Join(root, "secret.txt")
+	if err := os.WriteFile(outside, []byte("secret"), 0o600); err != nil {
+		t.Fatalf("write outside: %v", err)
+	}
+	link := filepath.Join(nested, "linked.md")
+	if err := os.Symlink(outside, link); err != nil {
+		t.Skipf("symlink not supported on %s: %v", runtime.GOOS, err)
+	}
+	if err := EnsureNoSymlinkEscape(filepath.Join(root, "content"), link); err == nil {
+		t.Fatal("expected symlink escape to be rejected")
+	}
+}
+
+func TestEnsureNoSymlinkEscapeRejectsSymlinkedRoot(t *testing.T) {
+	root := t.TempDir()
+	realRoot := filepath.Join(root, "real-content")
+	if err := os.MkdirAll(realRoot, 0o755); err != nil {
+		t.Fatalf("mkdir real root: %v", err)
+	}
+	linkedRoot := filepath.Join(root, "content")
+	if err := os.Symlink(realRoot, linkedRoot); err != nil {
+		t.Skipf("symlink not supported on %s: %v", runtime.GOOS, err)
+	}
+
+	if err := EnsureNoSymlinkEscape(linkedRoot, filepath.Join(linkedRoot, "posts", "hello.md")); err == nil {
+		t.Fatal("expected symlinked root to be rejected")
+	}
+}
+
+func TestEnsureNoSymlinkEscapeRejectsSymlinkedDirectoryComponent(t *testing.T) {
+	root := t.TempDir()
+	contentRoot := filepath.Join(root, "content")
+	if err := os.MkdirAll(filepath.Join(contentRoot, "posts"), 0o755); err != nil {
+		t.Fatalf("mkdir content root: %v", err)
+	}
+	outside := filepath.Join(t.TempDir(), "outside")
+	if err := os.MkdirAll(outside, 0o755); err != nil {
+		t.Fatalf("mkdir outside root: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(outside, "hello.md"), []byte("hello"), 0o600); err != nil {
+		t.Fatalf("write outside file: %v", err)
+	}
+	linkedDir := filepath.Join(contentRoot, "posts")
+	if err := os.RemoveAll(linkedDir); err != nil {
+		t.Fatalf("remove posts dir: %v", err)
+	}
+	if err := os.Symlink(outside, linkedDir); err != nil {
+		t.Skipf("symlink not supported on %s: %v", runtime.GOOS, err)
+	}
+
+	if err := EnsureNoSymlinkEscape(contentRoot, filepath.Join(linkedDir, "hello.md")); err == nil {
+		t.Fatal("expected symlinked directory component to be rejected")
+	}
+}

--- a/internal/theme/manage.go
+++ b/internal/theme/manage.go
@@ -165,7 +165,11 @@ func LoadManifest(themesDir, name string) (*Manifest, error) {
 		return nil, err
 	}
 
-	path := filepath.Join(themesDir, name, "theme.yaml")
+	root := filepath.Join(themesDir, name)
+	path := filepath.Join(root, "theme.yaml")
+	if err := safepath.EnsureNoSymlinkEscape(root, path); err != nil {
+		return nil, err
+	}
 	b, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {

--- a/internal/theme/manage_test.go
+++ b/internal/theme/manage_test.go
@@ -3,6 +3,7 @@ package theme
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -225,6 +226,129 @@ func TestValidateInstalledDetailedChecksThemeSecurity(t *testing.T) {
 	}
 	if !result.Valid {
 		t.Fatalf("expected security declaration to validate, got %#v", result.Diagnostics)
+	}
+}
+
+func TestLoadManifestRejectsSymlinkedManifest(t *testing.T) {
+	root := t.TempDir()
+	themeRoot := filepath.Join(root, "symlink-theme")
+	if err := os.MkdirAll(themeRoot, 0o755); err != nil {
+		t.Fatalf("mkdir theme root: %v", err)
+	}
+	outside := filepath.Join(t.TempDir(), "theme.yaml")
+	if err := os.WriteFile(outside, []byte("name: symlink-theme\n"), 0o644); err != nil {
+		t.Fatalf("write outside manifest: %v", err)
+	}
+	if err := os.Symlink(outside, filepath.Join(themeRoot, "theme.yaml")); err != nil {
+		t.Skipf("symlink not supported on %s: %v", runtime.GOOS, err)
+	}
+
+	if _, err := LoadManifest(root, "symlink-theme"); err == nil {
+		t.Fatal("expected symlinked manifest to be rejected")
+	}
+}
+
+func TestLoadManifestRejectsSymlinkRoot(t *testing.T) {
+	root := t.TempDir()
+	realTheme := filepath.Join(root, "real-theme")
+	if err := os.MkdirAll(realTheme, 0o755); err != nil {
+		t.Fatalf("mkdir theme root: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(realTheme, "theme.yaml"), []byte("name: linked-theme\n"), 0o644); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+	if err := os.Symlink(realTheme, filepath.Join(root, "linked-theme")); err != nil {
+		t.Skipf("symlink not supported on %s: %v", runtime.GOOS, err)
+	}
+
+	if _, err := LoadManifest(root, "linked-theme"); err == nil {
+		t.Fatal("expected symlinked theme root to be rejected")
+	}
+}
+
+func TestValidateInstalledDetailedRejectsSymlinkedLayout(t *testing.T) {
+	root := t.TempDir()
+	scaffolded, err := Scaffold(root, "layout-theme")
+	if err != nil {
+		t.Fatalf("scaffold theme: %v", err)
+	}
+	outside := filepath.Join(t.TempDir(), "page.html")
+	if err := os.WriteFile(outside, []byte(`{{ define "content" }}outside{{ end }}`), 0o644); err != nil {
+		t.Fatalf("write outside layout: %v", err)
+	}
+	layoutPath := filepath.Join(scaffolded, "layouts", "page.html")
+	if err := os.Remove(layoutPath); err != nil {
+		t.Fatalf("remove layout: %v", err)
+	}
+	if err := os.Symlink(outside, layoutPath); err != nil {
+		t.Skipf("symlink not supported on %s: %v", runtime.GOOS, err)
+	}
+
+	result, err := ValidateInstalledDetailed(root, "layout-theme")
+	if err != nil {
+		t.Fatalf("validate detailed: %v", err)
+	}
+	if result.Valid {
+		t.Fatal("expected symlinked layout to invalidate theme")
+	}
+}
+
+func TestValidateInstalledDetailedRejectsSymlinkRoot(t *testing.T) {
+	root := t.TempDir()
+	realTheme := filepath.Join(root, "real-theme")
+	if err := os.MkdirAll(realTheme, 0o755); err != nil {
+		t.Fatalf("mkdir theme root: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(realTheme, "theme.yaml"), []byte(`name: linked-theme
+title: Linked Theme
+version: 0.1.0
+min_foundry_version: 0.1.0
+sdk_version: v1
+compatibility_version: v1
+layouts: [base, index, page, post, list]
+slots: [head.end, body.start, body.end, page.before_main, page.after_main, page.before_content, page.after_content, post.before_header, post.after_header, post.before_content, post.after_content, post.sidebar.top, post.sidebar.overview, post.sidebar.bottom]
+`), 0o644); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+	if err := os.Symlink(realTheme, filepath.Join(root, "linked-theme")); err != nil {
+		t.Skipf("symlink not supported on %s: %v", runtime.GOOS, err)
+	}
+
+	result, err := ValidateInstalledDetailed(root, "linked-theme")
+	if err != nil {
+		t.Fatalf("validate detailed: %v", err)
+	}
+	if result.Valid {
+		t.Fatal("expected symlinked root to invalidate theme")
+	}
+	var found bool
+	for _, diagnostic := range result.Diagnostics {
+		if strings.Contains(strings.ToLower(diagnostic.Message), "symlink") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected symlink diagnostic, got %#v", result.Diagnostics)
+	}
+}
+
+func TestManagerMustExistRejectsSymlinkRoot(t *testing.T) {
+	root := t.TempDir()
+	themeRoot := filepath.Join(root, "linked-theme")
+	if err := os.MkdirAll(filepath.Join(root, "real-theme"), 0o755); err != nil {
+		t.Fatalf("mkdir theme root: %v", err)
+	}
+	if err := os.Symlink(filepath.Join(root, "real-theme"), themeRoot); err != nil {
+		t.Skipf("symlink not supported on %s: %v", runtime.GOOS, err)
+	}
+
+	mgr := NewManager(root, "linked-theme")
+	if err := mgr.MustExist(); err == nil {
+		t.Fatal("expected symlinked theme root to be rejected")
+	}
+	if err := ValidateInstalled(root, "linked-theme"); err == nil {
+		t.Fatal("expected symlinked theme root validation to fail")
 	}
 }
 

--- a/internal/theme/manager.go
+++ b/internal/theme/manager.go
@@ -39,9 +39,12 @@ func (m *Manager) MustExist() error {
 	}
 
 	themeDir := filepath.Join(m.root, themeName)
-	info, err := os.Stat(themeDir)
+	info, err := os.Lstat(themeDir)
 	if err != nil {
 		return fmt.Errorf("active theme not found: %w", err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("theme path is a symlink: %s", themeDir)
 	}
 	if !info.IsDir() {
 		return fmt.Errorf("theme path is not a directory: %s", themeDir)

--- a/internal/theme/validation.go
+++ b/internal/theme/validation.go
@@ -50,6 +50,14 @@ func ValidateInstalledDetailed(themesDir, name string) (*ValidationResult, error
 		}
 		return nil, err
 	}
+	if symlinkInfo, lstatErr := os.Lstat(root); lstatErr == nil && symlinkInfo.Mode()&os.ModeSymlink != 0 {
+		result := &ValidationResult{Valid: false, Diagnostics: []ValidationDiagnostic{{
+			Severity: "error",
+			Path:     filepath.ToSlash(root),
+			Message:  "theme path is a symlink",
+		}}}
+		return result, nil
+	}
 	if !info.IsDir() {
 		return nil, fmt.Errorf("theme path %q is not a directory", root)
 	}
@@ -85,6 +93,10 @@ func ValidateInstalledDetailed(themesDir, name string) (*ValidationResult, error
 	requiredLayouts := manifest.RequiredLayouts()
 	for _, layout := range requiredLayouts {
 		path := filepath.Join(root, "layouts", layout+".html")
+		if err := safepath.EnsureNoSymlinkEscape(root, path); err != nil {
+			add("error", path, err.Error())
+			continue
+		}
 		if _, err := os.Stat(path); err != nil {
 			if os.IsNotExist(err) {
 				add("error", path, "missing required theme layout")
@@ -100,6 +112,10 @@ func ValidateInstalledDetailed(themesDir, name string) (*ValidationResult, error
 		filepath.Join(root, "layouts", "partials", "footer.html"),
 	}
 	for _, path := range requiredPartials {
+		if err := safepath.EnsureNoSymlinkEscape(root, path); err != nil {
+			add("error", path, err.Error())
+			continue
+		}
 		if _, err := os.Stat(path); err != nil {
 			if os.IsNotExist(err) {
 				add("error", path, "missing required theme partial")
@@ -162,6 +178,9 @@ func validateThemeSecurityDetailed(root string, manifest *Manifest, add func(sev
 	assetAllowlist := themeExternalAssetAllowlist(manifest.Security)
 	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
+			return err
+		}
+		if err := safepath.EnsureNoSymlinkEscape(root, path); err != nil {
 			return err
 		}
 		if d.IsDir() {
@@ -288,6 +307,10 @@ func validateRequiredLaunchSlotsDetailed(root string, manifest *Manifest, add fu
 
 	for slot, relPath := range requiredLaunchSlotFiles {
 		path := filepath.Join(root, relPath)
+		if err := safepath.EnsureNoSymlinkEscape(root, path); err != nil {
+			add("error", path, err.Error())
+			continue
+		}
 		body, err := os.ReadFile(path)
 		if err != nil {
 			if os.IsNotExist(err) {
@@ -323,6 +346,10 @@ func validateTemplateReferences(root string, manifest *Manifest, add func(severi
 	files, _ := filepath.Glob(filepath.Join(root, "layouts", "*.html"))
 	files = append(files, partials...)
 	for _, path := range files {
+		if err := safepath.EnsureNoSymlinkEscape(root, path); err != nil {
+			add("error", path, err.Error())
+			continue
+		}
 		body, err := os.ReadFile(path)
 		if err != nil {
 			continue
@@ -348,6 +375,12 @@ func validateTemplateParsing(root string, add func(severity, path, message strin
 	files = append(files, partials...)
 	if len(files) == 0 {
 		return
+	}
+	for _, path := range files {
+		if err := safepath.EnsureNoSymlinkEscape(root, path); err != nil {
+			add("error", path, err.Error())
+			return
+		}
 	}
 	_, err := template.New("validate").Funcs(template.FuncMap{
 		"safeHTML": func(v any) template.HTML { return "" },

--- a/scripts/cmd/e2e-cleanup/main.go
+++ b/scripts/cmd/e2e-cleanup/main.go
@@ -38,6 +38,9 @@ func main() {
 	if err := cleanupAudit(filepath.Join(cfg.DataDir, "admin", "audit.jsonl")); err != nil {
 		fatalf("cleanup audit: %v", err)
 	}
+	if err := cleanupPlaywrightOutputs("."); err != nil {
+		fatalf("cleanup playwright outputs: %v", err)
+	}
 }
 
 func cleanupContent(root string) error {
@@ -185,6 +188,19 @@ func cleanupAudit(path string) error {
 	out := bytes.Join(filtered, []byte{'\n'})
 	out = append(out, '\n')
 	return os.WriteFile(path, out, 0o644)
+}
+
+func cleanupPlaywrightOutputs(root string) error {
+	if strings.TrimSpace(root) == "" {
+		root = "."
+	}
+	for _, name := range []string{"test-results", "playwright-report"} {
+		target := filepath.Join(root, name)
+		if err := os.RemoveAll(target); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func fatalf(format string, args ...any) {

--- a/scripts/cmd/e2e-cleanup/main_test.go
+++ b/scripts/cmd/e2e-cleanup/main_test.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCleanupPlaywrightOutputsRemovesReportDirs(t *testing.T) {
+	root := t.TempDir()
+	for _, name := range []string{"test-results", "playwright-report"} {
+		if err := os.MkdirAll(filepath.Join(root, name), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", name, err)
+		}
+		if err := os.WriteFile(filepath.Join(root, name, "artifact.txt"), []byte("artifact"), 0o644); err != nil {
+			t.Fatalf("write %s artifact: %v", name, err)
+		}
+	}
+
+	if err := cleanupPlaywrightOutputs(root); err != nil {
+		t.Fatalf("cleanup playwright outputs: %v", err)
+	}
+	for _, name := range []string{"test-results", "playwright-report"} {
+		if _, err := os.Stat(filepath.Join(root, name)); !os.IsNotExist(err) {
+			t.Fatalf("expected %s to be removed, got err=%v", name, err)
+		}
+	}
+}
+
+func TestCleanupPlaywrightOutputsHandlesEmptyRoot(t *testing.T) {
+	if err := cleanupPlaywrightOutputs("   "); err != nil {
+		t.Fatalf("cleanup should ignore empty root: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Hardens Foundry's filesystem and admin surfaces against symlink-based escape attacks, and add regression coverage so those paths stay closed.

## What changed

- Added a shared internal/safepath symlink guard and wired it into content loading, theme manifest loading, theme validation, theme template rendering, and plugin admin asset serving.
- Updated theme validation to report symlinked roots and symlinked layouts as validation failures instead of allowing them through or aborting inconsistently.
- Added regression tests covering symlinked content, symlinked plugin assets, symlinked theme manifests/layouts/roots, and the new path-confined helper behavior.
- Extended the e2e cleanup command so make test-e2e removes test-results/ and playwright-report/ after the run, whether Playwright passes or fails.

## Why

The repo had multiple filesystem entry points that relied on lexical path checks but still followed symlinks, which could let content, theme, or plugin asset reads escape their intended roots. That is a real defense-in-depth and data exposure risk in a CMS. The test additions lock those fixes in place so future refactors do not reintroduce the same class of bug, and the e2e cleanup change keeps local test runs from leaving stale artifacts behind.

## Testing

Describe how this was tested.

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `go run ./cmd/plugin-sync`
- [x] Manual testing performed
- [x] Added or updated tests where appropriate

## Screenshots or output

Include screenshots, logs, or terminal output if relevant.

## Checklist

- [x] I have read the contributing guidelines
- [x] I have kept this PR focused in scope
- [ ] I have updated documentation if needed
- [x] I have updated generated/plugin-related files if needed
- [x] This change does not introduce known security issues