### PR TITLE
swap go report for golangci-lint

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,37 @@
+name: GolangCI-Lint
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: golangci-lint-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # The linter compares the change with its parent commit.
+          fetch-depth: 2
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: "1.25"
+          cache: true
+
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v9
+        with:
+          version: v2.11.4
+          args: --new-from-rev=HEAD~1

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,19 @@
+version: "2"
+
+run:
+  timeout: 5m
+  relative-path-mode: gomod
+
+linters:
+  default: standard
+  enable:
+    - asciicheck
+    - bodyclose
+    - dogsled
+    - errorlint
+    - gosec
+    - nolintlint
+    - unconvert
+  exclusions:
+    generated: strict
+    warn-unused: true

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://img.shields.io/github/actions/workflow/status/sphireinc/foundry/build.yml?branch=main)](https://github.com/sphireinc/foundry/actions)
 [![CodeQL](https://github.com/sphireinc/Foundry/actions/workflows/github-code-scanning/codeql/badge.svg?branch=main)](https://github.com/sphireinc/Foundry/actions/workflows/github-code-scanning/codeql)
 [![Pages](https://github.com/sphireinc/Foundry/actions/workflows/pages/pages-build-deployment/badge.svg)](https://github.com/sphireinc/Foundry/actions/workflows/pages/pages-build-deployment)
-[![Go Report Card](https://goreportcard.com/badge/github.com/sphireinc/foundry)](https://goreportcard.com/report/github.com/sphireinc/foundry)
+[![GolangCI-Lint](https://github.com/sphireinc/foundry/actions/workflows/golangci-lint.yml/badge.svg?branch=main)](https://github.com/sphireinc/foundry/actions/workflows/golangci-lint.yml)
 ![Last Commit](https://img.shields.io/github/last-commit/sphireinc/foundry)
 
 <p align="center">


### PR DESCRIPTION
## Summary

Describe the purpose of this change.

## What changed

- removed go report badge from README
- added golangci-lint CI in runner
- added golangci-lint badge in README

## Why

Go Report was sunset (https://goreportcard.com/), and this project requires a replacement checker 

<img width="1638" height="944" alt="Screenshot 2026-07-09 at 10 54 16 PM" src="https://github.com/user-attachments/assets/3211f43b-b332-4207-b947-ef63d3e621ee" />

## Testing

Describe how this was tested.

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `go run ./cmd/plugin-sync`
- [ ] Manual testing performed
- [ ] Added or updated tests where appropriate

## Screenshots or output

Include screenshots, logs, or terminal output if relevant.

## Checklist

- [x] I have read the contributing guidelines
- [x] I have kept this PR focused in scope
- [x] I have updated documentation if needed
- [ ] I have updated generated/plugin-related files if needed
- [x] This change does not introduce known security issues