### PR TITLE
Debounce the editor's raw document rebuild while typing

### DIFF
--- a/tests/e2e/admin.spec.js
+++ b/tests/e2e/admin.spec.js
@@ -102,6 +102,44 @@ async function openHelloWorldInEditor(page) {
   await openDocumentInEditor(page, 'hello world', 'content/posts/hello-world.md');
 }
 
+// Editing a document from the documents list routes straight into the editor,
+// so this waits on the editor itself rather than the list's Open Editor button.
+async function openSeededDocumentInEditor(page, query, sourcePath) {
+  await page.getByRole('link', { name: /^Documents$/i }).click();
+  await expect(page.getByRole('heading', { name: /^Find Documents$/i })).toBeVisible();
+
+  await page.getByLabel(/Search Documents/i).fill(query);
+  await page.getByRole('button', { name: /^Search$/i }).click();
+
+  const documentRow = page.locator('.table-row', { hasText: sourcePath });
+  await expect(documentRow).toHaveCount(1);
+  await documentRow.locator('[data-edit-document]').click();
+
+  await expect(page).toHaveURL(/\/__admin\/editor$/);
+  await expect(page.locator('#document-source-path')).toHaveValue(sourcePath);
+}
+
+async function openZenMode(page) {
+  await page.locator('#document-zen-button').click();
+  await expect(page.locator('#zen-editor .ql-editor')).toBeVisible({ timeout: 15_000 });
+}
+
+async function seedPageForEditor(page, slug, sourcePath, title) {
+  await createDocumentViaAdminAPI(page, 'page', slug, 'en', 'page');
+  await saveDocumentViaAdminAPI(
+    page,
+    sourcePath,
+    buildDocumentRaw({
+      title,
+      slug,
+      layout: 'page',
+      body: `# ${title}\n\nInitial body.\n`,
+      draft: false,
+    }),
+    'e2e zen seed'
+  );
+}
+
 async function getDocumentViaAdminAPI(page, sourcePath) {
   const result = await adminGet(
     page,
@@ -391,6 +429,82 @@ test.describe('default admin theme', () => {
     await expect(page).toHaveURL(/\/__admin\/documents$/);
     await expect(page.getByRole('heading', { name: /^Preview$/i })).toBeVisible();
     await expect(page.locator('iframe').first()).toBeVisible();
+  });
+
+  test('zen mode coalesces raw sync while typing', async ({ page }) => {
+    await login(page);
+    await ensureFrontendTheme(page, 'default');
+
+    const slug = `e2e-zen-sync-${Date.now()}`;
+    const sourcePath = `content/pages/${slug}.md`;
+
+    try {
+      await seedPageForEditor(page, slug, sourcePath, 'E2E Zen Sync');
+      await openSeededDocumentInEditor(page, slug, sourcePath);
+      await openZenMode(page);
+
+      // The edits run in one synchronous burst, so no debounce timer can fire
+      // between them: whatever is counted here is per-edit work.
+      const syncsDuringBurst = await page.evaluate(() => {
+        window.__zenRawSyncs = 0;
+        document.addEventListener(
+          'input',
+          (event) => {
+            if (event.target && event.target.id === 'document-raw') {
+              window.__zenRawSyncs += 1;
+            }
+          },
+          true
+        );
+        const quill = window.Quill.find(document.getElementById('zen-editor'));
+        for (let index = 0; index < 10; index += 1) {
+          quill.insertText(quill.getLength() - 1, 'z', 'user');
+        }
+        return window.__zenRawSyncs;
+      });
+
+      expect(syncsDuringBurst, 'typing must not rebuild the raw document per edit').toBe(0);
+      await expect.poll(() => page.evaluate(() => window.__zenRawSyncs)).toBe(1);
+      await expect(page.locator('#document-raw')).toHaveValue(/zzzzzzzzzz/);
+    } finally {
+      if (page.isClosed()) {
+        return;
+      }
+      await deleteDocumentViaAdminAPI(page, sourcePath);
+    }
+  });
+
+  test('saving from zen mode keeps edits made inside the debounce window', async ({ page }) => {
+    await login(page);
+    await ensureFrontendTheme(page, 'default');
+
+    const slug = `e2e-zen-save-${Date.now()}`;
+    const sourcePath = `content/pages/${slug}.md`;
+    const marker = `zenflush${Date.now()}`;
+
+    try {
+      await seedPageForEditor(page, slug, sourcePath, 'E2E Zen Save');
+      await openSeededDocumentInEditor(page, slug, sourcePath);
+      await openZenMode(page);
+
+      await page.evaluate((text) => {
+        const quill = window.Quill.find(document.getElementById('zen-editor'));
+        quill.insertText(quill.getLength() - 1, text, 'user');
+      }, marker);
+      // The save lands inside the debounce window, so it only carries the
+      // marker when the pending editor sync is flushed first.
+      await expect(page.locator('#document-raw')).not.toHaveValue(new RegExp(marker));
+      await page.locator('#zen-save-document').click();
+
+      await expect(page.getByText(/Document saved\./i)).toBeVisible();
+      const detail = await getDocumentViaAdminAPI(page, sourcePath);
+      expect(detail.raw_body).toContain(marker);
+    } finally {
+      if (page.isClosed()) {
+        return;
+      }
+      await deleteDocumentViaAdminAPI(page, sourcePath);
+    }
   });
 
   test('media upload and metadata save flow work', async ({ page }) => {

--- a/themes/admin-themes/default/assets/admin/editor/quill.js
+++ b/themes/admin-themes/default/assets/admin/editor/quill.js
@@ -1,3 +1,7 @@
+// Rebuilding the raw document from the editor walks the whole body, so it runs
+// once the typist pauses instead of once per keystroke.
+const RAW_SYNC_DEBOUNCE_MS = 250;
+
 const loadStylesheet = (href) => {
   if (
     [...document.querySelectorAll('link[data-quill-style]')].some(
@@ -489,6 +493,8 @@ export const createQuillEditorController = ({
   let quillPromise = null;
   let zenPreviewTimer = null;
   let zenPreviewRequestId = 0;
+  let rawSyncTimer = null;
+  let pendingRawSync = null;
   let primaryQuill = null;
   let zenQuill = null;
   let primaryMount = null;
@@ -500,6 +506,13 @@ export const createQuillEditorController = ({
     if (zenPreviewTimer) {
       window.clearTimeout(zenPreviewTimer);
       zenPreviewTimer = null;
+    }
+  };
+
+  const clearRawSyncTimer = () => {
+    if (rawSyncTimer) {
+      window.clearTimeout(rawSyncTimer);
+      rawSyncTimer = null;
     }
   };
 
@@ -537,6 +550,8 @@ export const createQuillEditorController = ({
   };
 
   const rebuildRawFromQuill = (quill, kind) => {
+    clearRawSyncTimer();
+    pendingRawSync = null;
     const rawNode = document.getElementById('document-raw');
     if (!rawNode) return;
     const parsed = parseDocumentEditor(
@@ -555,6 +570,25 @@ export const createQuillEditorController = ({
     }
   };
 
+  const flushRawSync = () => {
+    if (!pendingRawSync) return;
+    const { quill, kind, sourcePath } = pendingRawSync;
+    // A queued rebuild belongs to the document it was typed into; dropping it on
+    // a document switch keeps stale body text out of the newly loaded one.
+    if (sourcePath !== state.documentEditor.source_path) {
+      clearRawSyncTimer();
+      pendingRawSync = null;
+      return;
+    }
+    rebuildRawFromQuill(quill, kind);
+  };
+
+  const queueRawSync = (quill, kind) => {
+    pendingRawSync = { quill, kind, sourcePath: state.documentEditor.source_path };
+    clearRawSyncTimer();
+    rawSyncTimer = window.setTimeout(flushRawSync, RAW_SYNC_DEBOUNCE_MS);
+  };
+
   const updatePreviewPane = (html) => {
     const pane = document.getElementById('zen-preview');
     if (!pane) return;
@@ -567,6 +601,7 @@ export const createQuillEditorController = ({
 
   const refreshPreview = async () => {
     if (!state.documentZenMode?.open) return;
+    flushRawSync();
     const requestId = ++zenPreviewRequestId;
     state.documentZenMode.loading = true;
     updateStatus('zen', 'Updating preview…');
@@ -714,7 +749,13 @@ export const createQuillEditorController = ({
     });
 
     quill.on('text-change', () => {
-      rebuildRawFromQuill(quill, kind);
+      queueRawSync(quill, kind);
+    });
+
+    // Leaving the editor settles the pending rebuild before any other control
+    // reads the raw document.
+    quill.root.addEventListener('blur', () => {
+      flushRawSync();
     });
   };
 
@@ -799,6 +840,7 @@ export const createQuillEditorController = ({
 
   const open = async () => {
     if (state.documentZenMode?.open) return;
+    flushRawSync();
     state.documentZenMode = {
       open: true,
       loading: true,
@@ -812,6 +854,7 @@ export const createQuillEditorController = ({
   };
 
   const close = () => {
+    flushRawSync();
     zenPreviewRequestId += 1;
     clearZenPreviewTimer();
     zenQuill = null;
@@ -826,10 +869,12 @@ export const createQuillEditorController = ({
   };
 
   const save = () => {
+    flushRawSync();
     document.getElementById('document-save-form')?.requestSubmit();
   };
 
   const disposeEditor = () => {
+    flushRawSync();
     clearZenPreviewTimer();
     zenQuill = null;
     zenMount = null;
@@ -844,6 +889,7 @@ export const createQuillEditorController = ({
     save,
     refreshPreview,
     queuePreviewRefresh,
+    flushRawSync,
     disposeEditor,
   };
 };

--- a/themes/admin-themes/default/assets/admin/events/dashboard.js
+++ b/themes/admin-themes/default/assets/admin/events/dashboard.js
@@ -382,6 +382,7 @@ export const bindDashboardEvents = (ctx) => {
     button.addEventListener('click', () => {
       const item = state.media.find((entry) => entry.reference === button.dataset.insertMedia);
       if (!item) return;
+      zenMode?.flushRawSync?.();
       insertIntoMarkdown(mediaSnippet(item, button.dataset.insertMode || 'auto'));
     });
   });
@@ -462,6 +463,7 @@ export const bindDashboardEvents = (ctx) => {
   });
 
   document.getElementById('editor-preview-documents')?.addEventListener('click', async () => {
+    zenMode?.flushRawSync?.();
     try {
       state.documentPreview = await admin.documents.preview({
         source_path:
@@ -480,6 +482,7 @@ export const bindDashboardEvents = (ctx) => {
 
   document.getElementById('document-save-form')?.addEventListener('submit', async (event) => {
     event.preventDefault();
+    zenMode?.flushRawSync?.();
     try {
       const saved = await admin.documents.save({
         source_path: document.getElementById('document-source-path').value,
@@ -522,6 +525,7 @@ export const bindDashboardEvents = (ctx) => {
   });
 
   document.getElementById('document-preview-button')?.addEventListener('click', async () => {
+    zenMode?.flushRawSync?.();
     try {
       state.documentPreview = await admin.documents.preview({
         source_path: document.getElementById('document-source-path').value,


### PR DESCRIPTION
This PR proposes debouncing the admin editor's raw-document rebuild so typing in Zen Mode stays responsive on large documents (refs #115). We include this PR work along with a full history of your repo at https://eastagiletracker.com/projects/291. You can sign in with your GitHub ID to claim ownership of the project.

## What was slow, and why

Issue #115 asks for a 1 second debounce on the preview update while typing, from @d9k's report that "editing is too slow and irritating now". The preview *fetch* is in fact already debounced at 1 second, and has been since the Quill editor landed in #95, so what is still blocking each keystroke is something else: the raw-document rebuild.

Every Quill `text-change` called `rebuildRawFromQuill()` synchronously. That does, per keystroke, an html-to-markdown walk of the entire body, a frontmatter parse of the current raw, a rebuild of the whole raw document, a write into the hidden `#document-raw` textarea, and an `input` dispatch whose handler parses the raw a second time, rewrites fourteen frontmatter fields and `JSON.stringify`s the document for the dirty-state snapshot. All of it is O(document), and all of it ran between the key going down and the character appearing.

## The change

`rebuildRawFromQuill()` now runs 250 ms after the last edit instead of on every edit, and is flushed on demand before anything reads the raw document: preview refresh (both the debounced one and the Refresh Preview button), Save Document (from Zen Mode and from the editor form), the Preview buttons, media insert, Zen Mode close, editor teardown, and editor blur — so clicking any control after typing settles the pending rebuild first. A pending rebuild is also dropped if the loaded document changed underneath it, so it can never write one document's body into another. The preview keeps its existing 1 second debounce and is still scheduled from the rebuild, so it now lands about 1.25 s after you stop typing rather than firing early against half-synced text.

Item 2 of the issue (button bar height) is untouched — it is a theme CSS change and reads as a separate decision.

## Reproducing and verifying

On current `main` (7779886), the new regression test fails, because ten edits produce ten full-document rebuilds:

```
$ npm run test:e2e -- -g "zen mode coalesces"
  1) [chromium] › tests/e2e/admin.spec.js › zen mode coalesces raw sync while typing
    Error: typing must not rebuild the raw document per edit
    expect(received).toBe(expected)
    Expected: 0
    Received: 10
```

The test drives ten `quill.insertText` calls inside one synchronous burst — no timer can fire between them — and counts `input` events on `#document-raw`, so the count is deterministic rather than timing-dependent. With this change it is 0 during the burst and exactly 1 once the editor settles, and the raw document then carries the typed text.

Measured cost of a 20-keystroke burst in Zen Mode on a 111 KB document, alternating runs of `main` and this branch in the same session (headless Chromium, `scripts/cmd/e2e-serve`):

| | raw rebuilds | typing wall time | main-thread long tasks |
| --- | --- | --- | --- |
| `main` | 20 | 1639 ms / 1461 ms | 1133 ms / 848 ms |
| this branch | 1 | 703 ms / 732 ms | 116 ms / 52 ms |

The second new test covers the risk this introduces: it inserts text and saves inside the 250 ms window, asserting first that the raw document has not caught up yet and then that the saved file contains the text anyway — that is the flush-on-save path, and without it a save right after typing would drop the last characters.

Verification on this branch: `go test ./...` and `go vet ./...` are green and match the pre-change baseline package for package; `gofmt -l .` is empty; `npx prettier --check` passes for both changed theme modules; and the full Playwright suite is 19/19 green (17 existing, plus the 2 new), run against a fresh `scripts/cmd/e2e-serve` workspace. Note that `npm run test:e2e` needs `PLAYWRIGHT_BASE_URL=http://localhost:8080` on a macOS host, where the default `127.0.0.1` base URL does not resolve to the dev server.

## How this was managed

This work was tracked on a live agile board imported from this repository's own issues and pull requests — 115 stories and 24 labels — with issue #115 as the story that carried it: https://eastagiletracker.com/projects/291/stories/181088. The board is at https://eastagiletracker.com/projects/291.

![board](https://raw.githubusercontent.com/eastagiletracker/Foundry/agile-board-assets/board.png)

If you'd rather not receive contributions like this, reply `no-more-prs` on this pull request and we won't open any further ones on your repositories.

---

**Lawrence W. Sinclair**
CEO / East Agile
[linkedin.com/in/lwsinclair/](https://linkedin.com/in/lwsinclair/)
[eastagile.com](https://eastagile.com)
